### PR TITLE
Feat/gitea connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 dist/
 build/
 .venv/
+.env
 .eggs/
 *.egg
 .pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.8] - 2026-06-03
+
+### Added
+
+- **Gitea**: wildcard owner/org source via `gitea:owner/*` to sync every repository under an owner into one Knowledge Base. Files are prefixed by repository name to avoid path collisions.
+
 ## [0.3.7] - 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.3.7] - 2026-06-02
+
+### Added
+
+- **Gitea**: repository source connector via `gitea:owner/repo`, configurable with `GITEA_URL` and optional `GITEA_TOKEN`. Supports branch and subdirectory scoping, uses Gitea Git tree blob SHAs for incremental sync checksums, and syncs files through the raw content API.
+
 ## [0.3.6] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ services:
 ```bash
 oikb sync github:owner/repo --kb-id your-kb-id
 GITEA_URL=https://gitea.example.com oikb sync gitea:owner/repo --kb-id your-kb-id
+GITEA_URL=https://gitea.example.com oikb sync 'gitea:owner/*' --kb-id your-kb-id
 oikb sync confluence:ENG --kb-id your-kb-id
 oikb sync s3://bucket/prefix --kb-id your-kb-id
 oikb sync servicenow:incident --kb-id your-kb-id

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📚 oikb
 
-Keep your [Open WebUI](https://github.com/open-webui/open-webui) Knowledge Bases in sync. Point it at a local directory, a GitHub repo, a Confluence space, an S3 bucket, or any of 44 supported sources. Only new and modified files are uploaded via incremental SHA-256 diffing.
+Keep your [Open WebUI](https://github.com/open-webui/open-webui) Knowledge Bases in sync. Point it at a local directory, a GitHub repo, a Confluence space, an S3 bucket, or any of 45 supported sources. Only new and modified files are uploaded via incremental SHA-256 diffing.
 
 > [!IMPORTANT]
 > Requires **Open WebUI 0.9.6+**
@@ -134,11 +134,11 @@ services:
       timeout: 5s
 ```
 
-## 44 Connectors
+## 45 Connectors
 
 | Category | Sources |
 |---|---|
-| **Code Repos** | GitHub, GitLab, Bitbucket |
+| **Code Repos** | GitHub, Gitea, GitLab, Bitbucket |
 | **Cloud Storage** | S3, GCS, Azure Blob, Dropbox, R2, Google Drive, SharePoint, Egnyte, Oracle Cloud |
 | **Wikis & KBs** | Confluence, Notion, BookStack, Discourse, GitBook, Guru, Outline, Slab, Document360, DokuWiki, Google Sites |
 | **Ticketing** | Jira, Linear, Zendesk, Freshdesk, Asana, ClickUp, Airtable, ServiceNow, ProductBoard |
@@ -150,6 +150,7 @@ services:
 
 ```bash
 oikb sync github:owner/repo --kb-id your-kb-id
+GITEA_URL=https://gitea.example.com oikb sync gitea:owner/repo --kb-id your-kb-id
 oikb sync confluence:ENG --kb-id your-kb-id
 oikb sync s3://bucket/prefix --kb-id your-kb-id
 oikb sync servicenow:incident --kb-id your-kb-id

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -18,6 +18,7 @@ A complete guide to syncing content into Open WebUI Knowledge Bases.
 - [Sources](#sources)
   - [Local Directories](#local-directories)
   - [GitHub](#github)
+  - [Gitea](#gitea)
   - [GitLab / Bitbucket](#gitlab--bitbucket)
   - [Confluence](#confluence)
   - [Cloud Storage (S3 / GCS / Azure)](#cloud-storage-s3--gcs--azure)
@@ -232,6 +233,31 @@ sources:
     path: docs/
 ```
 
+### Gitea
+
+```bash
+export GITEA_URL=https://gitea.example.com
+export GITEA_TOKEN=your-token  # required for private repos
+oikb sync gitea:owner/repo --kb-id your-kb-id
+```
+
+Gitea requires `GITEA_URL` because instances are self-hosted. Set `GITEA_TOKEN` for private repositories or higher API limits. Like GitHub, Gitea syncs the default branch by default and supports branch and subdirectory selection:
+
+```bash
+oikb sync gitea:owner/repo --branch main --path docs/
+```
+
+Or in `.oikb.yaml`:
+
+```yaml
+sources:
+  - name: gitea-docs
+    source: gitea:myorg/docs
+    kb-id: abc123
+    branch: main
+    path: docs/
+```
+
 ### GitLab / Bitbucket
 
 ```bash
@@ -316,11 +342,11 @@ sources:
 
 ### All Connectors
 
-44 connectors available. See the full list:
+45 connectors available. See the full list:
 
 | Category | Sources |
 |---|---|
-| **Git** | GitHub, GitLab, Bitbucket |
+| **Git** | GitHub, Gitea, GitLab, Bitbucket |
 | **Cloud Storage** | S3, GCS, Azure Blob, Dropbox, R2, Google Drive, SharePoint, Egnyte, Oracle Cloud |
 | **Wikis & KBs** | Confluence, Notion, BookStack, Discourse, GitBook, Guru, Outline, Slab, Document360, DokuWiki, Google Sites |
 | **Ticketing** | Jira, Linear, Zendesk, Freshdesk, Asana, ClickUp, Airtable, ServiceNow, ProductBoard |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -247,6 +247,12 @@ Gitea requires `GITEA_URL` because instances are self-hosted. Set `GITEA_TOKEN` 
 oikb sync gitea:owner/repo --branch main --path docs/
 ```
 
+To sync every repository owned by a Gitea user or organization, use `*` as the repository name. Files are stored under a repository-name prefix to prevent collisions:
+
+```bash
+oikb sync gitea:owner/* --kb-id your-kb-id
+```
+
 Or in `.oikb.yaml`:
 
 ```yaml
@@ -256,6 +262,10 @@ sources:
     kb-id: abc123
     branch: main
     path: docs/
+
+  - name: all-gitea-repos
+    source: gitea:myorg/*
+    kb-id: abc123
 ```
 
 ### GitLab / Bitbucket

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oikb"
-version = "0.3.6"
+version = "0.3.7"
 description = "Sync anything to Open WebUI Knowledge Bases"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oikb"
-version = "0.3.7"
+version = "0.3.8"
 description = "Sync anything to Open WebUI Knowledge Bases"
 readme = "README.md"
 authors = [

--- a/src/oikb/__init__.py
+++ b/src/oikb/__init__.py
@@ -1,3 +1,3 @@
 """oikb — Open WebUI Knowledge Base CLI."""
 
-__version__ = "0.3.5"
+__version__ = "0.3.7"

--- a/src/oikb/__init__.py
+++ b/src/oikb/__init__.py
@@ -1,3 +1,3 @@
 """oikb — Open WebUI Knowledge Base CLI."""
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -718,7 +718,7 @@ def status(url: str | None, token: str | None, kb: str | None):
 
     try:
         info = client.get_kb(kb)
-        files = info.get("files", [])
+        files = info.get("files") or []
     except Exception as e:
         click.echo(click.style(f"Failed: {e}", fg="red"), err=True)
         sys.exit(1)

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -50,6 +50,11 @@ def _resolve_connector(source: str, branch: str | None = None, path: str | None 
         parsed = parse_github_source(source)
         return GitHubConnector(owner=parsed["owner"], repo=parsed["repo"], branch=branch, path=path or parsed.get("path"))
 
+    if source.startswith("gitea:"):
+        from oikb.connectors.gitea import GiteaConnector, parse_gitea_source
+        parsed = parse_gitea_source(source)
+        return GiteaConnector(owner=parsed["owner"], repo=parsed["repo"], branch=branch, path=path or parsed.get("path"))
+
     if source.startswith("gitlab:"):
         from oikb.connectors.gitlab import GitLabConnector, parse_gitlab_source
         parsed = parse_gitlab_source(source)
@@ -349,7 +354,7 @@ def _build_cli_filter(max_file_size: str | None):
 @cli.command()
 @click.argument("source", required=False)
 @common_options
-@click.option("--branch", default=None, help="Branch for GitHub sources.")
+@click.option("--branch", default=None, help="Branch for Git repository sources.")
 @click.option("--path", "source_path", default=None, help="Subdirectory within the source.")
 @click.option("--dry-run", is_flag=True, help="Preview changes without uploading.")
 @click.option("-v", "--verbose", is_flag=True, help="Show detailed progress.")
@@ -506,7 +511,7 @@ def sync(
 @cli.command()
 @click.argument("source")
 @common_options
-@click.option("--branch", default=None, help="Branch for GitHub sources.")
+@click.option("--branch", default=None, help="Branch for Git repository sources.")
 @click.option("--path", "source_path", default=None, help="Subdirectory within the source.")
 @click.option("-v", "--verbose", is_flag=True, help="Show detailed output.")
 @click.pass_context

--- a/src/oikb/client.py
+++ b/src/oikb/client.py
@@ -135,4 +135,4 @@ class OikbClient:
         resp = self._http.get(f"/knowledge/{kb_id}")
         resp.raise_for_status()
         data = resp.json()
-        return data.get("files", [])
+        return data.get("files") or []

--- a/src/oikb/connectors/gitea.py
+++ b/src/oikb/connectors/gitea.py
@@ -1,0 +1,168 @@
+"""Gitea connector — sync a Gitea repo to a Knowledge Base via the API.
+
+Uses the Gitea Git Trees API for checksums (blob SHAs) — no local clone needed.
+Set GITEA_URL to your instance URL, and GITEA_TOKEN for private repositories.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from oikb.connectors import BaseConnector, ManifestEntry
+
+
+class GiteaConnector(BaseConnector):
+    """Sync files from a Gitea repository.
+
+    Args:
+        owner:    Repository owner or organization.
+        repo:     Repository name.
+        branch:   Branch to sync from (default: repo default branch).
+        path:     Subdirectory to scope to (e.g. "docs/").
+        token:    Gitea personal access token (or GITEA_TOKEN env var).
+        base_url: Gitea instance URL (or GITEA_URL env var).
+    """
+
+    def __init__(
+        self,
+        owner: str,
+        repo: str,
+        branch: str | None = None,
+        path: str | None = None,
+        token: str | None = None,
+        base_url: str | None = None,
+    ):
+        self.owner = owner
+        self.repo = repo
+        self.branch = branch
+        self.path = path.strip("/") if path else None
+        self._token = token or os.environ.get("GITEA_TOKEN")
+        self._base_url = (base_url or os.environ.get("GITEA_URL") or "").rstrip("/")
+        self._default_branch: str | None = None
+
+        if not self._base_url:
+            raise ValueError("GITEA_URL is required for gitea: sources (e.g. https://gitea.example.com)")
+
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"token {self._token}"
+
+        self._http = httpx.Client(
+            base_url=f"{self._base_url}/api/v1",
+            headers=headers,
+            timeout=60.0,
+        )
+
+    def build_manifest(self) -> list[ManifestEntry]:
+        """Fetch the repo tree and build a manifest.
+
+        Gitea paginates the recursive tree endpoint. Blob SHAs are used as
+        checksums because they are content-addressable hashes.
+        """
+        ref = self.branch or self._get_default_branch()
+        entries: list[ManifestEntry] = []
+        seen_items = 0
+        page = 1
+
+        while True:
+            resp = self._http.get(
+                f"/repos/{self.owner}/{self.repo}/git/trees/{ref}",
+                params={"recursive": "true", "per_page": 100, "page": page},
+            )
+            resp.raise_for_status()
+            tree = resp.json()
+            items = tree.get("tree", [])
+
+            if not items:
+                break
+
+            seen_items += len(items)
+
+            for item in items:
+                if item.get("type") != "blob":
+                    continue
+
+                file_path = item["path"]
+
+                # Filter by path prefix if specified.
+                if self.path:
+                    if not file_path.startswith(self.path + "/"):
+                        continue
+                    # Strip the prefix so paths are relative to the scoped dir.
+                    file_path = file_path[len(self.path) + 1 :]
+
+                parts = file_path.rsplit("/", 1)
+                if len(parts) == 2:
+                    dir_path, filename = parts
+                else:
+                    dir_path, filename = "", parts[0]
+
+                entries.append(
+                    ManifestEntry(
+                        filename=filename,
+                        path=dir_path,
+                        checksum=item["sha"],  # Git blob SHA — content-addressable.
+                        size=item.get("size", 0),
+                    )
+                )
+
+            total_count = tree.get("total_count")
+            if total_count is not None:
+                if seen_items >= total_count:
+                    break
+            elif len(items) < 100:
+                break
+
+            page += 1
+
+        entries.sort(key=lambda e: e.display_path)
+        return entries
+
+    def read_file(self, path: str, filename: str) -> bytes:
+        """Download a file's raw content via the Gitea raw file endpoint."""
+        file_path = f"{path}/{filename}" if path else filename
+
+        if self.path:
+            file_path = f"{self.path}/{file_path}"
+
+        ref = self.branch or self._get_default_branch()
+
+        resp = self._http.get(
+            f"/repos/{self.owner}/{self.repo}/raw/{file_path}",
+            params={"ref": ref},
+        )
+        resp.raise_for_status()
+        return resp.content
+
+    def _get_default_branch(self) -> str:
+        """Fetch and cache the repo's default branch name."""
+        if self._default_branch is None:
+            resp = self._http.get(f"/repos/{self.owner}/{self.repo}")
+            resp.raise_for_status()
+            self._default_branch = resp.json()["default_branch"]
+        return self._default_branch
+
+    def close(self) -> None:
+        self._http.close()
+
+
+def parse_gitea_source(source: str) -> dict[str, str | None]:
+    """Parse a gitea:owner/repo[/path] source string.
+
+    Examples:
+        gitea:myorg/docs
+        gitea:myorg/docs/api
+    """
+    source = source.removeprefix("gitea:")
+
+    parts = source.split("/", 2)
+    if len(parts) < 2:
+        raise ValueError(f"Invalid Gitea source: {source}. Expected: gitea:owner/repo")
+
+    owner = parts[0]
+    repo = parts[1]
+    path = parts[2] if len(parts) > 2 else None
+
+    return {"owner": owner, "repo": repo, "path": path}

--- a/src/oikb/connectors/gitea.py
+++ b/src/oikb/connectors/gitea.py
@@ -1,4 +1,4 @@
-"""Gitea connector — sync a Gitea repo to a Knowledge Base via the API.
+"""Gitea connector — sync Gitea repos to a Knowledge Base via the API.
 
 Uses the Gitea Git Trees API for checksums (blob SHAs) — no local clone needed.
 Set GITEA_URL to your instance URL, and GITEA_TOKEN for private repositories.
@@ -14,11 +14,11 @@ from oikb.connectors import BaseConnector, ManifestEntry
 
 
 class GiteaConnector(BaseConnector):
-    """Sync files from a Gitea repository.
+    """Sync files from one Gitea repository, or all repos for an owner.
 
     Args:
         owner:    Repository owner or organization.
-        repo:     Repository name.
+        repo:     Repository name, or "*" for all repos owned by owner.
         branch:   Branch to sync from (default: repo default branch).
         path:     Subdirectory to scope to (e.g. "docs/").
         token:    Gitea personal access token (or GITEA_TOKEN env var).
@@ -40,7 +40,7 @@ class GiteaConnector(BaseConnector):
         self.path = path.strip("/") if path else None
         self._token = token or os.environ.get("GITEA_TOKEN")
         self._base_url = (base_url or os.environ.get("GITEA_URL") or "").rstrip("/")
-        self._default_branch: str | None = None
+        self._default_branches: dict[str, str] = {}
 
         if not self._base_url:
             raise ValueError("GITEA_URL is required for gitea: sources (e.g. https://gitea.example.com)")
@@ -61,14 +61,25 @@ class GiteaConnector(BaseConnector):
         Gitea paginates the recursive tree endpoint. Blob SHAs are used as
         checksums because they are content-addressable hashes.
         """
-        ref = self.branch or self._get_default_branch()
+        if self._all_repos:
+            entries: list[ManifestEntry] = []
+            for repo in self._list_repos():
+                entries.extend(self._build_repo_manifest(repo, prefix_repo=True))
+            entries.sort(key=lambda e: e.display_path)
+            return entries
+
+        return self._build_repo_manifest(self.repo)
+
+    def _build_repo_manifest(self, repo: str, prefix_repo: bool = False) -> list[ManifestEntry]:
+        """Fetch one repo tree and build manifest entries."""
+        ref = self.branch or self._get_default_branch(repo)
         entries: list[ManifestEntry] = []
         seen_items = 0
         page = 1
 
         while True:
             resp = self._http.get(
-                f"/repos/{self.owner}/{self.repo}/git/trees/{ref}",
+                f"/repos/{self.owner}/{repo}/git/trees/{ref}",
                 params={"recursive": "true", "per_page": 100, "page": page},
             )
             resp.raise_for_status()
@@ -99,6 +110,9 @@ class GiteaConnector(BaseConnector):
                 else:
                     dir_path, filename = "", parts[0]
 
+                if prefix_repo:
+                    dir_path = f"{repo}/{dir_path}" if dir_path else repo
+
                 entries.append(
                     ManifestEntry(
                         filename=filename,
@@ -123,26 +137,60 @@ class GiteaConnector(BaseConnector):
     def read_file(self, path: str, filename: str) -> bytes:
         """Download a file's raw content via the Gitea raw file endpoint."""
         file_path = f"{path}/{filename}" if path else filename
+        repo = self.repo
+
+        if self._all_repos:
+            repo, _, file_path = file_path.partition("/")
+            if not repo or not file_path:
+                raise ValueError(f"Invalid wildcard Gitea path: {path}/{filename}")
 
         if self.path:
             file_path = f"{self.path}/{file_path}"
 
-        ref = self.branch or self._get_default_branch()
+        ref = self.branch or self._get_default_branch(repo)
 
         resp = self._http.get(
-            f"/repos/{self.owner}/{self.repo}/raw/{file_path}",
+            f"/repos/{self.owner}/{repo}/raw/{file_path}",
             params={"ref": ref},
         )
         resp.raise_for_status()
         return resp.content
 
-    def _get_default_branch(self) -> str:
+    @property
+    def _all_repos(self) -> bool:
+        return self.repo == "*"
+
+    def _get_default_branch(self, repo: str) -> str:
         """Fetch and cache the repo's default branch name."""
-        if self._default_branch is None:
-            resp = self._http.get(f"/repos/{self.owner}/{self.repo}")
+        if repo not in self._default_branches:
+            resp = self._http.get(f"/repos/{self.owner}/{repo}")
             resp.raise_for_status()
-            self._default_branch = resp.json()["default_branch"]
-        return self._default_branch
+            self._default_branches[repo] = resp.json()["default_branch"]
+        return self._default_branches[repo]
+
+    def _list_repos(self) -> list[str]:
+        """List repositories for the configured owner or organization."""
+        repos: list[str] = []
+        page = 1
+
+        while True:
+            resp = self._http.get(f"/orgs/{self.owner}/repos", params={"page": page, "limit": 50})
+            if resp.status_code == 404:
+                resp = self._http.get(f"/users/{self.owner}/repos", params={"page": page, "limit": 50})
+            resp.raise_for_status()
+            items = resp.json()
+
+            if not items:
+                break
+
+            repos.extend(repo["name"] for repo in items)
+
+            if len(items) < 50:
+                break
+            page += 1
+
+        repos.sort()
+        return repos
 
     def close(self) -> None:
         self._http.close()
@@ -154,6 +202,7 @@ def parse_gitea_source(source: str) -> dict[str, str | None]:
     Examples:
         gitea:myorg/docs
         gitea:myorg/docs/api
+        gitea:myorg/*
     """
     source = source.removeprefix("gitea:")
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from oikb import cli as cli_module
+from oikb.cli import cli
+
+
+class DummyClient:
+    def get_kb(self, kb_id: str) -> dict:
+        return {
+            "id": kb_id,
+            "name": "Docs",
+            "description": "",
+            "files": None,
+        }
+
+    def close(self) -> None:
+        pass
+
+
+def test_status_handles_null_files(monkeypatch) -> None:
+    monkeypatch.setattr(cli_module, "resolve_url", lambda value=None: "https://openwebui.example.com")
+    monkeypatch.setattr(cli_module, "resolve_token", lambda value=None: "token")
+    monkeypatch.setattr("oikb.client.OikbClient", lambda *args, **kwargs: DummyClient())
+
+    result = CliRunner().invoke(cli, ["status", "--kb-id", "kb123"])
+
+    assert result.exit_code == 0
+    assert "Knowledge Base: Docs" in result.output
+    assert "Files:       0" in result.output

--- a/tests/test_gitea_connector.py
+++ b/tests/test_gitea_connector.py
@@ -16,6 +16,14 @@ def test_parse_gitea_source_with_path() -> None:
     }
 
 
+def test_parse_gitea_source_with_wildcard() -> None:
+    assert parse_gitea_source("gitea:owner/*") == {
+        "owner": "owner",
+        "repo": "*",
+        "path": None,
+    }
+
+
 def test_parse_gitea_source_rejects_missing_repo() -> None:
     with pytest.raises(ValueError, match="Expected: gitea:owner/repo"):
         parse_gitea_source("gitea:owner")
@@ -84,6 +92,35 @@ def test_build_manifest_scopes_path_and_paginates() -> None:
 
 
 @respx.mock
+def test_build_manifest_with_wildcard_prefixes_repo_names() -> None:
+    base = "https://gitea.example.com/api/v1"
+    respx.get(f"{base}/orgs/owner/repos").mock(
+        return_value=Response(200, json=[{"name": "repo-a"}, {"name": "repo-b"}])
+    )
+    respx.get(f"{base}/repos/owner/repo-a").mock(return_value=Response(200, json={"default_branch": "main"}))
+    respx.get(f"{base}/repos/owner/repo-b").mock(return_value=Response(200, json={"default_branch": "trunk"}))
+    respx.get(f"{base}/repos/owner/repo-a/git/trees/main").mock(
+        return_value=Response(
+            200,
+            json={"total_count": 1, "tree": [{"path": "README.md", "type": "blob", "sha": "a", "size": 1}]},
+        )
+    )
+    respx.get(f"{base}/repos/owner/repo-b/git/trees/trunk").mock(
+        return_value=Response(
+            200,
+            json={"total_count": 1, "tree": [{"path": "docs/index.md", "type": "blob", "sha": "b", "size": 2}]},
+        )
+    )
+
+    connector = GiteaConnector(owner="owner", repo="*", base_url="https://gitea.example.com")
+
+    manifest = connector.build_manifest()
+
+    assert [entry.display_path for entry in manifest] == ["repo-a/README.md", "repo-b/docs/index.md"]
+    assert [entry.checksum for entry in manifest] == ["a", "b"]
+
+
+@respx.mock
 def test_read_file_downloads_raw_content_with_path_scope() -> None:
     base = "https://gitea.example.com/api/v1"
     route = respx.get(f"{base}/repos/owner/repo/raw/docs/sub/file.md").mock(
@@ -99,4 +136,18 @@ def test_read_file_downloads_raw_content_with_path_scope() -> None:
     )
 
     assert connector.read_file("sub", "file.md") == b"hello"
+    assert route.calls.last.request.url.params["ref"] == "main"
+
+
+@respx.mock
+def test_read_file_with_wildcard_routes_to_repo_from_path() -> None:
+    base = "https://gitea.example.com/api/v1"
+    respx.get(f"{base}/repos/owner/repo-a").mock(return_value=Response(200, json={"default_branch": "main"}))
+    route = respx.get(f"{base}/repos/owner/repo-a/raw/docs/file.md").mock(
+        return_value=Response(200, content=b"hello")
+    )
+
+    connector = GiteaConnector(owner="owner", repo="*", base_url="https://gitea.example.com")
+
+    assert connector.read_file("repo-a/docs", "file.md") == b"hello"
     assert route.calls.last.request.url.params["ref"] == "main"

--- a/tests/test_gitea_connector.py
+++ b/tests/test_gitea_connector.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+
+from oikb.cli import _resolve_connector
+from oikb.connectors.gitea import GiteaConnector, parse_gitea_source
+
+
+def test_parse_gitea_source_with_path() -> None:
+    assert parse_gitea_source("gitea:owner/repo/docs/api") == {
+        "owner": "owner",
+        "repo": "repo",
+        "path": "docs/api",
+    }
+
+
+def test_parse_gitea_source_rejects_missing_repo() -> None:
+    with pytest.raises(ValueError, match="Expected: gitea:owner/repo"):
+        parse_gitea_source("gitea:owner")
+
+
+def test_gitea_connector_requires_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITEA_URL", raising=False)
+
+    with pytest.raises(ValueError, match="GITEA_URL is required"):
+        GiteaConnector(owner="owner", repo="repo")
+
+
+def test_resolve_connector_dispatches_gitea(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITEA_URL", "https://gitea.example.com")
+
+    connector = _resolve_connector("gitea:owner/repo/docs", branch="main")
+
+    assert isinstance(connector, GiteaConnector)
+    assert connector.owner == "owner"
+    assert connector.repo == "repo"
+    assert connector.branch == "main"
+    assert connector.path == "docs"
+    connector.close()
+
+
+@respx.mock
+def test_build_manifest_scopes_path_and_paginates() -> None:
+    base = "https://gitea.example.com/api/v1"
+    respx.get(f"{base}/repos/owner/repo/git/trees/main").mock(
+        side_effect=[
+            Response(
+                200,
+                json={
+                    "total_count": 3,
+                    "tree": [
+                        {"path": "README.md", "type": "blob", "sha": "root", "size": 10},
+                        {"path": "docs/a.md", "type": "blob", "sha": "sha-a", "size": 20},
+                    ],
+                },
+            ),
+            Response(
+                200,
+                json={
+                    "total_count": 3,
+                    "tree": [
+                        {"path": "docs/sub/b.md", "type": "blob", "sha": "sha-b", "size": 30},
+                    ],
+                },
+            ),
+        ]
+    )
+
+    connector = GiteaConnector(
+        owner="owner",
+        repo="repo",
+        branch="main",
+        path="docs",
+        base_url="https://gitea.example.com",
+    )
+
+    manifest = connector.build_manifest()
+
+    assert [entry.display_path for entry in manifest] == ["a.md", "sub/b.md"]
+    assert [entry.checksum for entry in manifest] == ["sha-a", "sha-b"]
+    assert [entry.size for entry in manifest] == [20, 30]
+
+
+@respx.mock
+def test_read_file_downloads_raw_content_with_path_scope() -> None:
+    base = "https://gitea.example.com/api/v1"
+    route = respx.get(f"{base}/repos/owner/repo/raw/docs/sub/file.md").mock(
+        return_value=Response(200, content=b"hello")
+    )
+
+    connector = GiteaConnector(
+        owner="owner",
+        repo="repo",
+        branch="main",
+        path="docs",
+        base_url="https://gitea.example.com",
+    )
+
+    assert connector.read_file("sub", "file.md") == b"hello"
+    assert route.calls.last.request.url.params["ref"] == "main"


### PR DESCRIPTION
This pull request introduces a new Gitea source connector to sync repositories from self-hosted Gitea instances into Open WebUI Knowledge Bases. The Gitea connector supports both single-repo and wildcard (all repos for an owner/org) syncing, with branch and subdirectory scoping, and uses Gitea's API for efficient incremental syncs. The documentation, CLI, and test suite have been updated accordingly. Additionally, minor robustness improvements were made to handle empty file lists in API responses.

**Gitea Connector Integration:**

* Added a new `GiteaConnector` in `src/oikb/connectors/gitea.py` to support syncing from Gitea repositories, including wildcard owner/org sources (`gitea:owner/*`) that sync all repositories under an owner, with files prefixed by repository name to avoid path collisions. Supports branch and subdirectory scoping, and uses the Gitea API for incremental sync checksums and file downloads.
* Updated the CLI (`src/oikb/cli.py`) to dispatch `gitea:` sources to the new connector, and clarified branch option help text to refer to "Git repository sources" instead of just GitHub. [[1]](diffhunk://#diff-0dc7516586245c7db1c8104a5ca133e053fc6a8d6288eb5b660d844ed64ca941R53-R57) [[2]](diffhunk://#diff-0dc7516586245c7db1c8104a5ca133e053fc6a8d6288eb5b660d844ed64ca941L352-R357) [[3]](diffhunk://#diff-0dc7516586245c7db1c8104a5ca133e053fc6a8d6288eb5b660d844ed64ca941L509-R514)

**Documentation Updates:**

* Updated `README.md` and `docs/guide.md` to document the new Gitea connector, example usage, and increased the connector count to 45. Gitea is now listed in all relevant tables and usage examples, including support for wildcard syncing and required environment variables. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R141) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R153-R154) [[4]](diffhunk://#diff-07fdd026b11c494c3b62c97f764f6939803c453389ebefd6b05e6f187d44859aR21) [[5]](diffhunk://#diff-07fdd026b11c494c3b62c97f764f6939803c453389ebefd6b05e6f187d44859aR236-R270) [[6]](diffhunk://#diff-07fdd026b11c494c3b62c97f764f6939803c453389ebefd6b05e6f187d44859aL319-R359)

**Robustness and Bugfixes:**

* Improved handling of `files` fields that may be `None` in API responses, ensuring that file lists default to empty lists to prevent errors in status reporting and file listing. [[1]](diffhunk://#diff-0dc7516586245c7db1c8104a5ca133e053fc6a8d6288eb5b660d844ed64ca941L716-R721) [[2]](diffhunk://#diff-96fa515156d1dcc9f334c734bfdf73405f564979901fa65434a90017ebecc325L138-R138)

**Testing:**

* Added comprehensive tests for the Gitea connector, including parsing, manifest building, wildcard repo handling, and file reading, as well as CLI integration tests.
* Added a test to ensure the CLI status command handles null `files` fields gracefully.

**Changelog and Versioning:**

* Updated `CHANGELOG.md` for versions 0.3.7 and 0.3.8 to document the addition of the Gitea connector and wildcard syncing.
* Bumped version numbers in `pyproject.toml` and `src/oikb/__init__.py` to 0.3.8. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-4edb420453ca7ec2c1e682b6e87afbf1ed891478147ea851bf1d7cbced573a31L3-R3)