### PR TITLE
Change deprecated JIRA API endpoint to the current one for JQL

### DIFF
--- a/src/oikb/connectors/jira.py
+++ b/src/oikb/connectors/jira.py
@@ -71,7 +71,7 @@ class JiraConnector(BaseConnector):
                     break
 
             resp = self._http.get(
-                "/rest/api/3/search",
+                "/rest/api/3/search/jql",
                 params={"jql": self._jql, "startAt": start, "maxResults": max_results,
                         "fields": ",".join(api_fields)},
             )


### PR DESCRIPTION
/rest/api/3/search was deprecated, changed to the current /rest/api/3/search/jql