### PR TITLE
fix(connectors/filesystem): prevent path traversal in read_file

### DIFF
--- a/src/oikb/connectors/filesystem.py
+++ b/src/oikb/connectors/filesystem.py
@@ -105,4 +105,11 @@ class FilesystemConnector(BaseConnector):
             file_path = self.root / path / filename
         else:
             file_path = self.root / filename
-        return file_path.read_bytes()
+            
+        resolved_path = file_path.resolve()
+        if not resolved_path.is_relative_to(self.root):
+            raise PermissionError(
+                f"Path traversal attempt detected: {filename} resolves outside the root directory."
+            )
+            
+        return resolved_path.read_bytes()


### PR DESCRIPTION
This pull request adds a security enhancement to the `read_file` method in `filesystem.py` to prevent directory traversal attacks. Now, before reading a file, the code checks that the resolved file path is within the allowed root directory.