### PR TITLE
fix: correct Docker config mount path to /data and improve error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docker run -d \
   -e OPEN_WEBUI_API_KEY=sk-... \
   -e OIKB_API_KEY=your-daemon-key \
   -e LOG_FORMAT=json \
-  -v ./.oikb.yaml:/app/.oikb.yaml:ro \
+  -v ./.oikb.yaml:/data/.oikb.yaml:ro \
   -p 8080:8080 \
   ghcr.io/open-webui/oikb:latest daemon
 ```
@@ -121,7 +121,7 @@ services:
       - OIKB_API_KEY=${OIKB_API_KEY}
       - LOG_FORMAT=json
     volumes:
-      - ./.oikb.yaml:/app/.oikb.yaml:ro
+      - ./.oikb.yaml:/data/.oikb.yaml:ro
     command: daemon
     ports:
       - "8080:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - OIKB_API_KEY=${OIKB_API_KEY}
       - LOG_FORMAT=json
     volumes:
-      - ./.oikb.yaml:/app/.oikb.yaml:ro
+      - ./.oikb.yaml:/data/.oikb.yaml:ro
     command: daemon
     ports:
       - "8080:8080"

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -940,7 +940,7 @@ def daemon(port: int, no_server: bool, config_file: str | None, log_format: str 
         entries = _load_oikb_yaml()
 
     if not entries:
-        click.echo(click.style("No sync entries found. Create a .oikb.yaml file.", fg="red"), err=True)
+        click.echo(click.style("No sync entries found. Create a .oikb.yaml file at {yaml_path}.", fg="red"), err=True)
         sys.exit(1)
 
     # Validate entries.


### PR DESCRIPTION
Fixes #43 

## Changes

- Update docker-compose.yaml to mount `.oikb.yaml` to `/data` instead of `/app`
- Update README.md Docker examples to use correct mount path
- Improve daemon error message to show full path to `.oikb.yaml`

## Why

The Dockerfile sets `WORKDIR /data`, but the current examples mount the config to `/app/.oikb.yaml`. This causes users to see "No sync entries found" errors. The improved error message will also aid troubleshooting.