### PR TITLE
Fixes #30

### DIFF
--- a/src/oikb/connectors/sharepoint.py
+++ b/src/oikb/connectors/sharepoint.py
@@ -132,7 +132,7 @@ class SharePointConnector(BaseConnector):
 
     def read_file(self, path: str, filename: str) -> bytes:
         file_path = f"{path}/{filename}" if path else filename
-        resp = self._http.get(f"/drives/{self._drive_id}/root:/{file_path}:/content")
+        resp = self._http.get(f"/drives/{self._drive_id}/root:/{file_path}:/content", follow_redirects=True)
         resp.raise_for_status()
         return resp.content
 


### PR DESCRIPTION
Fixes #30

## Changes
- Update sharepoint connector to now tell the HTTP client to follow redirects when reading files.

## Why
The Graph API returns a 302 redirect to a temporary download URL for file content, but sharepoint connector isn't following that redirect it's treating the 302 as an error.
