### PR TITLE
Handle missing Nextcloud folders gracefully (HTTP 404)

### DIFF
--- a/src/oikb/connectors/nextcloud.py
+++ b/src/oikb/connectors/nextcloud.py
@@ -70,7 +70,14 @@ class _WebDAVClient:
             return
         seen_dirs.add(folder_path)
 
-        for entry in self._propfind(folder_path):
+        try:
+            children = self._propfind(folder_path)
+        except httpx.HTTPStatusError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return
+            raise
+
+        for entry in children:
             if entry.path == folder_path:
                 continue
             if entry.is_collection:


### PR DESCRIPTION
While syncing a Nextcloud source, a single missing folder currently aborts the entire sync process:

PROPFIND ... failed: HTTP 404

This can happen when:

a configured folder has been deleted or renamed;
a shared folder is no longer available;
permissions change between sync runs.

Proposed change:

Catch HTTPStatusError with status code 404 during folder traversal (_walk_folder). Log a warning indicating that the folder was skipped. Continue processing the remaining folders/files instead of failing the whole synchronization job.