### PR TITLE
feat(zotero): add Zotero connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 .DS_Store
 Thumbs.db
 uv.lock
+
+# Personal, untracked scratch (scripts, configs, secrets)
+perso/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Zotero**: `ZOTERO_INCLUDE_NOTES` and `ZOTERO_INCLUDE_ANNOTATIONS` env flags. When enabled, an item's child-note text and its PDF highlights/comments are appended to the extracted `.txt` (a `=== NOTES ===` section, then an `=== ANNOTATIONS ===` section); items with notes but no PDF surface as their own notes-only file. Change detection works in both `version` and `content` checksum modes.
+- **Zotero**: a whole-library sync (`zotero:` with no hierarchy) now also picks up items that are in no collection and places them under `ZOTERO_UNFILED_DIR` (default `_unfiled/`). Previously only items inside collections were synced. A named hierarchy is unchanged and never includes unfiled items.
 
 ## [0.3.6] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **Zotero**: `ZOTERO_INCLUDE_NOTES` and `ZOTERO_INCLUDE_ANNOTATIONS` env flags. When enabled, an item's child-note text and its PDF highlights/comments are appended to the extracted `.txt` (a `=== NOTES ===` section, then an `=== ANNOTATIONS ===` section); items with notes but no PDF surface as their own notes-only file. Change detection works in both `version` and `content` checksum modes.
+
 ## [0.3.6] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ oikb sync "zotero:Research%%Machine Learning" --kb-id your-kb-id
 | `ZOTERO_LIBRARY_TYPE` | `user` or `group` (default: `user`) |
 | `ZOTERO_API_KEY` | Zotero API key (required) |
 | `ZOTERO_CHECKSUM` | Change detection: `version` (cheap, default) or `content` (hashes extracted text) |
-| `ZOTERO_EXCLUDE` | `;`-separated collection paths to skip, e.g. `Research%%Archive;Research%%Drafts` |
+| `ZOTERO_EXCLUDE` | `;`-separated subcollection paths to skip, relative to the synced root (e.g. when syncing `zotero:Research`, use `Archive;Drafts`) |
 
 Text is taken from Zotero's indexed fulltext when available, falling back to extracting it
 from the PDF with PyMuPDF. Requires the extra: `pip install oikb[zotero]`.

--- a/README.md
+++ b/README.md
@@ -180,9 +180,19 @@ oikb sync "zotero:Research%%Machine Learning" --kb-id your-kb-id
 | `ZOTERO_API_KEY` | Zotero API key (required) |
 | `ZOTERO_CHECKSUM` | Change detection: `version` (cheap, default) or `content` (hashes extracted text) |
 | `ZOTERO_EXCLUDE` | `;`-separated subcollection paths to skip, relative to the synced root (e.g. when syncing `zotero:Research`, use `Archive;Drafts`) |
+| `ZOTERO_INCLUDE_NOTES` | When truthy (`1`/`true`/`yes`/`on`), append child-note text to each item's `.txt`. Items that have notes but no PDF surface as their own notes-only file. |
+| `ZOTERO_INCLUDE_ANNOTATIONS` | When truthy, append PDF highlights and comments to each attachment's `.txt`. |
 
 Text is taken from Zotero's indexed fulltext when available, falling back to extracting it
 from the PDF with PyMuPDF. Requires the extra: `pip install oikb[zotero]`.
+
+With `ZOTERO_INCLUDE_NOTES` and/or `ZOTERO_INCLUDE_ANNOTATIONS` enabled, an attachment's
+`.txt` is the PDF body, then a `=== NOTES ===` section, then an `=== ANNOTATIONS ===`
+section. Notes come back with the item's children for free, but annotations are children of
+the attachment, so enabling them costs one extra API call per attachment in `version`
+checksum mode (`content` mode already downloads everything). Change detection stays correct
+in both modes: editing a note or annotation, which bumps only its own version, still updates
+the file.
 
 ## Filters
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ services:
 | **Meetings** | Gong, Fireflies |
 | **Forums** | XenForo |
 | **Sales & CRM** | Salesforce, HubSpot |
+| **Reference Managers** | Zotero |
 | **Web** | Website / Sitemap crawler |
 
 ```bash
@@ -154,9 +155,34 @@ oikb sync confluence:ENG --kb-id your-kb-id
 oikb sync s3://bucket/prefix --kb-id your-kb-id
 oikb sync nextcloud:/Documents --kb-id your-kb-id
 oikb sync servicenow:incident --kb-id your-kb-id
+oikb sync "zotero:Research%%Machine Learning" --kb-id your-kb-id
 ```
 
-Some connectors need an optional extra: `pip install oikb[gdrive]`, `pip install oikb[s3]`, or `pip install oikb[all]` for everything.
+Some connectors need an optional extra: `pip install oikb[gdrive]`, `pip install oikb[s3]`, `pip install oikb[zotero]`, or `pip install oikb[all]` for everything.
+
+### Zotero
+
+Syncs the text of PDF attachments in a Zotero collection to a Knowledge Base. The
+collection hierarchy maps to KB directories, and the connector is read-only with respect
+to Zotero (it never modifies your library). Source syntax uses `%%` as the hierarchy
+separator; an empty hierarchy (`zotero:`) syncs every top-level collection.
+
+```bash
+export ZOTERO_LIBRARY_ID=123456
+export ZOTERO_API_KEY=xxxxxxxx
+oikb sync "zotero:Research%%Machine Learning" --kb-id your-kb-id
+```
+
+| Variable | Description |
+|---|---|
+| `ZOTERO_LIBRARY_ID` | Zotero library id (required) |
+| `ZOTERO_LIBRARY_TYPE` | `user` or `group` (default: `user`) |
+| `ZOTERO_API_KEY` | Zotero API key (required) |
+| `ZOTERO_CHECKSUM` | Change detection: `version` (cheap, default) or `content` (hashes extracted text) |
+| `ZOTERO_EXCLUDE` | `;`-separated collection paths to skip, e.g. `Research%%Archive;Research%%Drafts` |
+
+Text is taken from Zotero's indexed fulltext when available, falling back to extracting it
+from the PDF with PyMuPDF. Requires the extra: `pip install oikb[zotero]`.
 
 ## Filters
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Some connectors need an optional extra: `pip install oikb[gdrive]`, `pip install
 Syncs the text of PDF attachments in a Zotero collection to a Knowledge Base. The
 collection hierarchy maps to KB directories, and the connector is read-only with respect
 to Zotero (it never modifies your library). Source syntax uses `%%` as the hierarchy
-separator; an empty hierarchy (`zotero:`) syncs every top-level collection.
+separator; an empty hierarchy (`zotero:`) syncs the whole library, every top-level
+collection plus any items sitting directly in "My Library" (in no collection).
 
 ```bash
 export ZOTERO_LIBRARY_ID=123456
@@ -182,6 +183,7 @@ oikb sync "zotero:Research%%Machine Learning" --kb-id your-kb-id
 | `ZOTERO_EXCLUDE` | `;`-separated subcollection paths to skip, relative to the synced root (e.g. when syncing `zotero:Research`, use `Archive;Drafts`) |
 | `ZOTERO_INCLUDE_NOTES` | When truthy (`1`/`true`/`yes`/`on`), append child-note text to each item's `.txt`. Items that have notes but no PDF surface as their own notes-only file. |
 | `ZOTERO_INCLUDE_ANNOTATIONS` | When truthy, append PDF highlights and comments to each attachment's `.txt`. |
+| `ZOTERO_UNFILED_DIR` | Virtual directory for library items in no collection, used by a whole-library (`zotero:`) sync (default: `_unfiled`). Exclude these items with `ZOTERO_EXCLUDE=_unfiled`. |
 
 Text is taken from Zotero's indexed fulltext when available, falling back to extracting it
 from the PDF with PyMuPDF. Requires the extra: `pip install oikb[zotero]`.
@@ -193,6 +195,12 @@ the attachment, so enabling them costs one extra API call per attachment in `ver
 checksum mode (`content` mode already downloads everything). Change detection stays correct
 in both modes: editing a note or annotation, which bumps only its own version, still updates
 the file.
+
+A whole-library sync (`zotero:` with no hierarchy) also picks up items that are in no
+collection and places them under `ZOTERO_UNFILED_DIR` (default `_unfiled/`). Zotero's API
+has no "unfiled" query, so this fetches the library's top-level items once and keeps those
+with an empty `collections` list. A named hierarchy (e.g. `zotero:Research`) syncs only that
+subtree and never sweeps unfiled items.
 
 ## Filters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ gsites = ["google-api-python-client>=2.100", "google-auth>=2.25"]
 web = ["beautifulsoup4>=4.12"]
 oracle = ["oci"]
 sharepoint-cert = ["cryptography>=42.0", "PyJWT>=2.8"]
+zotero = ["pyzotero>=1.5", "pymupdf>=1.24"]
 all = [
     "boto3>=1.34",
     "google-cloud-storage>=2.14",
@@ -43,6 +44,8 @@ all = [
     "oci",
     "cryptography>=42.0",
     "PyJWT>=2.8",
+    "pyzotero>=1.5",
+    "pymupdf>=1.24",
 ]
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23", "respx>=0.21"]
 

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -273,6 +273,11 @@ def _resolve_connector(source: str, branch: str | None = None, path: str | None 
             limit=int(parsed.get("limit", "1000")),
         )
 
+    if source.startswith("zotero:"):
+        from oikb.connectors.zotero import ZoteroConnector, parse_zotero_source
+        parsed = parse_zotero_source(source)
+        return ZoteroConnector(hierarchy=parsed.get("hierarchy"))
+
     # Default: local filesystem.
     from oikb.connectors.filesystem import FilesystemConnector
     return FilesystemConnector(source)

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -453,6 +453,8 @@ def sync(
                     prefix = "Dry run" if dry_run else "Done"
                     click.echo(f"  {prefix}: {result.summary()}")
 
+                _echo_warnings(result.warnings)
+
                 if result.errors:
                     has_errors = True
 
@@ -504,11 +506,29 @@ def sync(
         prefix = "Dry run" if dry_run else "Sync complete"
         click.echo(f"{prefix}: {result.summary()}")
 
+    _echo_warnings(result.warnings)
+
     if result.errors:
         click.echo(click.style(f"\n{len(result.errors)} error(s):", fg="red"), err=True)
         for err in result.errors:
             click.echo(f"  • {err}", err=True)
         sys.exit(1)
+
+
+def _echo_warnings(warnings: list[str] | None) -> None:
+    """Print non-fatal skip warnings (source files with no retrievable content).
+
+    These never affect the exit code; only result.errors does. Printed here, after
+    the run, because the live progress bar that shows them is transient.
+    """
+    if not warnings:
+        return
+    click.echo(
+        click.style(f"\n{len(warnings)} warning(s) (skipped, not fatal):", fg="yellow"),
+        err=True,
+    )
+    for w in warnings:
+        click.echo(f"  • {w}", err=True)
 
 
 # ── diff ────────────────────────────────────────────────────────

--- a/src/oikb/connectors/__init__.py
+++ b/src/oikb/connectors/__init__.py
@@ -6,6 +6,20 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 
+class SourceFileUnavailable(Exception):
+    """A file listed in the manifest has no retrievable content at the source.
+
+    Raised by a connector's read_file() when the source advertised a file but its
+    bytes cannot be fetched through no fault of oikb, e.g. a Zotero attachment
+    whose file isn't in storage (a web-link / linked-file / WebDAV-only item).
+
+    The sync treats this as a *non-fatal* skip: the file is left out of the
+    Knowledge Base and reported as a warning, so a run whose only problems are
+    unavailable source files still succeeds (exit 0). Any other exception from
+    read_file() remains a hard error that fails the sync.
+    """
+
+
 @dataclass(frozen=True, slots=True)
 class ManifestEntry:
     """A single file in the source manifest.

--- a/src/oikb/connectors/zotero.py
+++ b/src/oikb/connectors/zotero.py
@@ -1,0 +1,281 @@
+"""Zotero connector — sync PDF text from a Zotero library to a Knowledge Base.
+
+Extracts text from the PDF attachments of items in a Zotero collection (and its
+subcollections) and uploads them as .txt files. The collection hierarchy maps to
+Knowledge Base directories.
+
+This connector is READ-ONLY with respect to Zotero: it never modifies, deletes, or
+adds anything to your Zotero library.
+
+Auth and options via env vars:
+  ZOTERO_LIBRARY_ID    Zotero library id (required)
+  ZOTERO_LIBRARY_TYPE  'user' or 'group' (default: user)
+  ZOTERO_API_KEY       Zotero API key (required)
+  ZOTERO_CHECKSUM      change-detection mode (default: version):
+                         'version' — cheap, hashes the Zotero item version (no download)
+                         'content' — hashes the extracted text (accurate, downloads all)
+  ZOTERO_EXCLUDE       ';'-separated collection paths to skip,
+                       e.g. "Research%%Archive;Research%%Drafts"
+
+Source syntax: zotero:<hierarchy> where hierarchy uses %% as the separator, e.g.
+  zotero:Research%%Machine Learning
+An empty hierarchy (just "zotero:") syncs every top-level collection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import tempfile
+
+from oikb.connectors import BaseConnector, ManifestEntry
+
+# Separator between collection names in a source hierarchy string.
+HIERARCHY_SEP = "%%"
+# Max filename length to stay well under filesystem / API limits.
+MAX_FILENAME = 200
+
+
+class ZoteroConnector(BaseConnector):
+    """Sync PDF text from a Zotero library to a Knowledge Base."""
+
+    def __init__(
+        self,
+        hierarchy: str | None = None,
+        library_id: str | None = None,
+        library_type: str | None = None,
+        api_key: str | None = None,
+        checksum: str | None = None,
+        exclude: str | None = None,
+    ):
+        self.hierarchy = hierarchy
+        lib_id = library_id or os.environ.get("ZOTERO_LIBRARY_ID", "")
+        lib_type = library_type or os.environ.get("ZOTERO_LIBRARY_TYPE", "user")
+        key = api_key or os.environ.get("ZOTERO_API_KEY", "")
+        if not lib_id or not key:
+            raise ValueError(
+                "Zotero credentials required. Set ZOTERO_LIBRARY_ID and ZOTERO_API_KEY."
+            )
+
+        self.checksum_mode = (checksum or os.environ.get("ZOTERO_CHECKSUM", "version")).lower()
+        if self.checksum_mode not in ("version", "content"):
+            raise ValueError(
+                f"Invalid ZOTERO_CHECKSUM '{self.checksum_mode}'. Use 'version' or 'content'."
+            )
+
+        exclude_raw = exclude if exclude is not None else os.environ.get("ZOTERO_EXCLUDE", "")
+        self.excluded_paths = {p.strip() for p in exclude_raw.split(";") if p.strip()}
+
+        try:
+            from pyzotero import zotero
+        except ImportError as e:
+            raise ImportError(
+                "pyzotero is required for the Zotero connector. Install with: pip install oikb[zotero]"
+            ) from e
+        self._zot = zotero.Zotero(lib_id, lib_type, key)
+
+        # (path, filename) -> attachment key, populated during build_manifest.
+        self._index: dict[tuple[str, str], str] = {}
+        # attachment key -> extracted text, so read_file (and content-mode
+        # checksumming) never extracts the same attachment twice.
+        self._text_cache: dict[str, str] = {}
+
+    # ── manifest ────────────────────────────────────────────────
+
+    def build_manifest(self) -> list[ManifestEntry]:
+        all_collections = self._zot.everything(self._zot.collections())
+        tree = self._build_tree(all_collections, None)
+
+        items: dict[str, dict] = {}
+        if self.hierarchy:
+            node = self._find_by_path(tree, self.hierarchy.split(HIERARCHY_SEP))
+            if node is None:
+                raise ValueError(f"Zotero collection path not found: {self.hierarchy}")
+            # Paths are relative to the synced collection, so it starts at root ("").
+            self._merge(items, self._collect_items(node["key"], all_collections, ""))
+        else:
+            # Whole library: each top-level collection becomes a top-level directory.
+            for node in tree:
+                self._merge(items, self._collect_items(node["key"], all_collections, node["name"]))
+
+        entries: list[ManifestEntry] = []
+        for item_key, data in items.items():
+            for path in data["paths"] or [""]:
+                kb_path = path.replace(HIERARCHY_SEP, "/")
+                for idx, att_key in enumerate(data["attachments"]):
+                    filename = self._unique(kb_path, self._make_filename(data["title"], idx))
+                    checksum, size = self._checksum(item_key, data["version"], att_key)
+                    self._index[(kb_path, filename)] = att_key
+                    entries.append(
+                        ManifestEntry(filename=filename, path=kb_path, checksum=checksum, size=size)
+                    )
+
+        entries.sort(key=lambda e: e.display_path)
+        return entries
+
+    def read_file(self, path: str, filename: str) -> bytes:
+        att_key = self._index.get((path, filename))
+        if att_key is None:
+            raise FileNotFoundError(f"Unknown Zotero file: {path}/{filename}")
+        return self._get_text(att_key).encode("utf-8")
+
+    # ── collection traversal ────────────────────────────────────
+
+    def _build_tree(self, all_collections: list[dict], parent_key: str | None) -> list[dict]:
+        """Build a hierarchical tree of collections under parent_key (None = top level)."""
+        if parent_key is None:
+            filtered = [c for c in all_collections if not c.get("data", {}).get("parentCollection")]
+        else:
+            filtered = [
+                c for c in all_collections if c.get("data", {}).get("parentCollection") == parent_key
+            ]
+        return [
+            {
+                "key": c["key"],
+                "name": c["data"]["name"],
+                "children": self._build_tree(all_collections, c["key"]),
+            }
+            for c in filtered
+        ]
+
+    def _find_by_path(self, tree: list[dict], path_parts: list[str]) -> dict | None:
+        """Navigate the tree following collection names; return the matching node."""
+        if not path_parts:
+            return None
+        for node in tree:
+            if node["name"] == path_parts[0]:
+                if len(path_parts) == 1:
+                    return node
+                return self._find_by_path(node["children"], path_parts[1:])
+        return None
+
+    def _collect_items(
+        self, collection_key: str, all_collections: list[dict], current_path: str
+    ) -> dict[str, dict]:
+        """Recursively gather items (with attachments) and the paths they appear under.
+
+        Returns a dict: item_key -> {title, version, paths, attachments}. An item that
+        lives in several subcollections records each path it appears under.
+        """
+        if self.excluded_paths and current_path:
+            for ex in self.excluded_paths:
+                if current_path == ex or current_path.startswith(f"{ex}{HIERARCHY_SEP}"):
+                    return {}
+
+        items: dict[str, dict] = {}
+        for item in self._zot.everything(self._zot.collection_items(collection_key)):
+            data = item.get("data", {})
+            if data.get("itemType") == "attachment":
+                continue  # standalone attachment, not a parent item
+            item_key = item["key"]
+            children = self._zot.everything(self._zot.children(item_key))
+            attachments = [
+                c["key"] for c in children if c.get("data", {}).get("itemType") == "attachment"
+            ]
+            if not attachments:
+                continue
+            if item_key not in items:
+                items[item_key] = {
+                    "title": data.get("title", "Untitled"),
+                    "version": item.get("version", data.get("version", 0)),
+                    "paths": [],
+                    "attachments": attachments,
+                }
+            if current_path:
+                if current_path not in items[item_key]["paths"]:
+                    items[item_key]["paths"].append(current_path)
+            elif not items[item_key]["paths"]:
+                items[item_key]["paths"].append("")
+
+        subcols = [
+            c for c in all_collections if c.get("data", {}).get("parentCollection") == collection_key
+        ]
+        for sub in subcols:
+            sub_name = sub["data"]["name"]
+            new_path = f"{current_path}{HIERARCHY_SEP}{sub_name}" if current_path else sub_name
+            self._merge(items, self._collect_items(sub["key"], all_collections, new_path))
+        return items
+
+    @staticmethod
+    def _merge(dest: dict[str, dict], src: dict[str, dict]) -> None:
+        """Merge src items into dest, unioning their path lists."""
+        for key, value in src.items():
+            if key not in dest:
+                dest[key] = value
+            else:
+                for path in value["paths"]:
+                    if path not in dest[key]["paths"]:
+                        dest[key]["paths"].append(path)
+
+    # ── naming, checksums, text extraction ──────────────────────
+
+    @staticmethod
+    def _make_filename(title: str, attachment_index: int, max_length: int = MAX_FILENAME) -> str:
+        """Build a sanitized .txt filename for an item attachment."""
+        name = re.sub(r"<[^>]+>", "", title)  # strip HTML tags Zotero embeds in titles
+        name = name.replace("/", "_").replace("\\", "_").strip() or "Untitled"
+        suffix = f"_{attachment_index + 1}" if attachment_index > 0 else ""
+        ext = ".txt"
+        budget = max_length - len(suffix) - len(ext)
+        if len(name) > budget:
+            name = name[: max(budget - 3, 10)] + "..."
+        return f"{name}{suffix}{ext}"
+
+    def _unique(self, path: str, filename: str) -> str:
+        """Disambiguate filename collisions within the same KB directory."""
+        if (path, filename) not in self._index:
+            return filename
+        stem, _, ext = filename.rpartition(".")
+        i = 2
+        while (path, f"{stem}__{i}.{ext}") in self._index:
+            i += 1
+        return f"{stem}__{i}.{ext}"
+
+    def _checksum(self, item_key: str, version: int, attachment_key: str) -> tuple[str, int]:
+        """Return (checksum, size) for an attachment per the configured checksum mode."""
+        if self.checksum_mode == "content":
+            data = self._get_text(attachment_key).encode("utf-8")
+            return hashlib.sha256(data).hexdigest(), len(data)
+        digest = hashlib.sha256(f"{item_key}:{version}:{attachment_key}".encode()).hexdigest()
+        return digest, 0  # size unknown without downloading
+
+    def _get_text(self, attachment_key: str) -> str:
+        """Extract (and cache) the text of a Zotero attachment."""
+        if attachment_key not in self._text_cache:
+            self._text_cache[attachment_key] = self._extract_text(attachment_key)
+        return self._text_cache[attachment_key]
+
+    def _extract_text(self, attachment_key: str) -> str:
+        """Get attachment text: Zotero's indexed fulltext first, else PyMuPDF on the PDF."""
+        try:
+            return self._zot.fulltext_item(attachment_key)["content"]
+        except Exception:
+            pass  # not indexed; fall back to downloading and extracting
+
+        pdf_bytes = self._zot.file(attachment_key)
+        try:
+            import fitz  # pymupdf
+        except ImportError as e:
+            raise ImportError(
+                "pymupdf is required for the Zotero connector. Install with: pip install oikb[zotero]"
+            ) from e
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(pdf_bytes)
+            tmp_path = tmp.name
+        try:
+            doc = fitz.open(tmp_path)
+            text = "".join(page.get_text() for page in doc)
+            doc.close()
+            return text
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def parse_zotero_source(source: str) -> dict[str, str | None]:
+    hierarchy = source.removeprefix("zotero:")
+    return {"hierarchy": hierarchy or None}

--- a/src/oikb/connectors/zotero.py
+++ b/src/oikb/connectors/zotero.py
@@ -236,8 +236,15 @@ class ZoteroConnector(BaseConnector):
     def _checksum(self, item_key: str, version: int, attachment_key: str) -> tuple[str, int]:
         """Return (checksum, size) for an attachment per the configured checksum mode."""
         if self.checksum_mode == "content":
-            data = self._get_text(attachment_key).encode("utf-8")
-            return hashlib.sha256(data).hexdigest(), len(data)
+            try:
+                data = self._get_text(attachment_key).encode("utf-8")
+                return hashlib.sha256(data).hexdigest(), len(data)
+            except Exception:
+                # Text isn't retrievable (e.g. no file in Zotero storage). Never let one
+                # bad attachment abort the whole manifest: fall back to the version
+                # checksum so the entry is still created, and the failure surfaces (and is
+                # reported) at upload time through the normal per-file error path.
+                pass
         digest = hashlib.sha256(f"{item_key}:{version}:{attachment_key}".encode()).hexdigest()
         return digest, 0  # size unknown without downloading
 
@@ -254,7 +261,16 @@ class ZoteroConnector(BaseConnector):
         except Exception:
             pass  # not indexed; fall back to downloading and extracting
 
-        pdf_bytes = self._zot.file(attachment_key)
+        try:
+            pdf_bytes = self._zot.file(attachment_key)
+        except Exception as e:
+            raise RuntimeError(
+                f"Zotero has no downloadable file for attachment {attachment_key} ({e}). "
+                "Its bytes aren't in Zotero storage, so neither the fulltext API nor the "
+                "file endpoint can return content. Check that file syncing is enabled and "
+                "your storage quota isn't exceeded, or whether this attachment is a web "
+                "link or a WebDAV-only / linked file."
+            ) from e
         try:
             import fitz  # pymupdf
         except ImportError as e:

--- a/src/oikb/connectors/zotero.py
+++ b/src/oikb/connectors/zotero.py
@@ -7,6 +7,10 @@ Knowledge Base directories.
 This connector is READ-ONLY with respect to Zotero: it never modifies, deletes, or
 adds anything to your Zotero library.
 
+An attachment whose file isn't downloadable from Zotero (web link, linked file, or
+bytes not in storage) is skipped with a warning rather than failing the sync: those
+are Zotero-side data gaps, not oikb errors.
+
 Auth and options via env vars:
   ZOTERO_LIBRARY_ID    Zotero library id (required)
   ZOTERO_LIBRARY_TYPE  'user' or 'group' (default: user)
@@ -30,7 +34,7 @@ import os
 import re
 import tempfile
 
-from oikb.connectors import BaseConnector, ManifestEntry
+from oikb.connectors import BaseConnector, ManifestEntry, SourceFileUnavailable
 
 # Separator between collection names in a source hierarchy string.
 HIERARCHY_SEP = "%%"
@@ -264,7 +268,11 @@ class ZoteroConnector(BaseConnector):
         try:
             pdf_bytes = self._zot.file(attachment_key)
         except Exception as e:
-            raise RuntimeError(
+            # The attachment exists in Zotero's metadata but its bytes aren't
+            # retrievable. This is a Zotero-side data gap, not an oikb failure, so
+            # raise SourceFileUnavailable: the sync skips this one file with a
+            # warning instead of aborting / failing the whole run.
+            raise SourceFileUnavailable(
                 f"Zotero has no downloadable file for attachment {attachment_key} ({e}). "
                 "Its bytes aren't in Zotero storage, so neither the fulltext API nor the "
                 "file endpoint can return content. Check that file syncing is enabled and "

--- a/src/oikb/connectors/zotero.py
+++ b/src/oikb/connectors/zotero.py
@@ -14,8 +14,9 @@ Auth and options via env vars:
   ZOTERO_CHECKSUM      change-detection mode (default: version):
                          'version' — cheap, hashes the Zotero item version (no download)
                          'content' — hashes the extracted text (accurate, downloads all)
-  ZOTERO_EXCLUDE       ';'-separated collection paths to skip,
-                       e.g. "Research%%Archive;Research%%Drafts"
+  ZOTERO_EXCLUDE       ';'-separated collection paths to skip, relative to the synced
+                       root and using %% as separator. When syncing
+                       "zotero:Research", exclude its subcollections as "Archive;Drafts".
 
 Source syntax: zotero:<hierarchy> where hierarchy uses %% as the separator, e.g.
   zotero:Research%%Machine Learning

--- a/src/oikb/connectors/zotero.py
+++ b/src/oikb/connectors/zotero.py
@@ -29,6 +29,9 @@ Auth and options via env vars:
                        (annotationText / annotationComment) to each attachment's .txt. In
                        'version' checksum mode this costs one extra API call per attachment,
                        since annotations are children of the attachment, not of the item.
+  ZOTERO_UNFILED_DIR   virtual directory name for library items that are in no collection
+                       (default: "_unfiled"). Only used by a whole-library sync. Exclude it
+                       entirely with ZOTERO_EXCLUDE=<that name>.
 
 When both are enabled, an attachment's .txt is the PDF body, then a "=== NOTES ==="
 section, then an "=== ANNOTATIONS ===" section. Change detection still works: 'content'
@@ -37,7 +40,10 @@ versions (editing a note or annotation bumps its own version, not the item's).
 
 Source syntax: zotero:<hierarchy> where hierarchy uses %% as the separator, e.g.
   zotero:Research%%Machine Learning
-An empty hierarchy (just "zotero:") syncs every top-level collection.
+An empty hierarchy (just "zotero:") syncs the whole library: every top-level collection
+becomes a directory, and items sitting directly in "My Library" (in no collection) are
+swept into the ZOTERO_UNFILED_DIR directory. A named hierarchy syncs only that subtree
+and never includes unfiled items.
 """
 
 from __future__ import annotations
@@ -69,6 +75,7 @@ class ZoteroConnector(BaseConnector):
         exclude: str | None = None,
         include_notes: bool | None = None,
         include_annotations: bool | None = None,
+        unfiled_dir: str | None = None,
     ):
         self.hierarchy = hierarchy
         lib_id = library_id or os.environ.get("ZOTERO_LIBRARY_ID", "")
@@ -98,6 +105,12 @@ class ZoteroConnector(BaseConnector):
             if include_annotations is not None
             else self._env_flag(os.environ.get("ZOTERO_INCLUDE_ANNOTATIONS", ""))
         )
+
+        # Virtual directory for items that live directly in the library (no collection).
+        raw_unfiled = (
+            unfiled_dir if unfiled_dir is not None else os.environ.get("ZOTERO_UNFILED_DIR", "")
+        )
+        self.unfiled_dir = raw_unfiled.strip().strip("/") or "_unfiled"
 
         try:
             from pyzotero import zotero
@@ -135,6 +148,9 @@ class ZoteroConnector(BaseConnector):
             # Whole library: each top-level collection becomes a top-level directory.
             for node in tree:
                 self._merge(items, self._collect_items(node["key"], all_collections, node["name"]))
+            # Items that live directly in the library (in no collection) are invisible to
+            # the collection walk, so sweep them into their own virtual directory.
+            self._merge(items, self._collect_unfiled())
 
         entries: list[ManifestEntry] = []
         for item_key, data in items.items():
@@ -211,47 +227,17 @@ class ZoteroConnector(BaseConnector):
         regardless of self.include_notes so callers can decide, but is only emitted when the
         flag is on.
         """
-        if self.excluded_paths and current_path:
-            for ex in self.excluded_paths:
-                if current_path == ex or current_path.startswith(f"{ex}{HIERARCHY_SEP}"):
-                    return {}
+        if self._is_excluded(current_path):
+            return {}
 
         items: dict[str, dict] = {}
         for item in self._zot.everything(self._zot.collection_items(collection_key)):
-            data = item.get("data", {})
-            item_type = data.get("itemType")
-            if item_type == "attachment":
-                continue  # standalone attachment, not a parent item
-            item_key = item["key"]
-            if item_type == "note":
-                # A top-level standalone note: it is its own content, has no children.
-                attachments = []
-                notes = [self._note_record(item)]
-                title = self._note_title(notes[0]["html"])
-            else:
-                children = self._zot.everything(self._zot.children(item_key))
-                attachments = [
-                    c["key"] for c in children if c.get("data", {}).get("itemType") == "attachment"
-                ]
-                notes = [
-                    self._note_record(c)
-                    for c in children
-                    if c.get("data", {}).get("itemType") == "note"
-                ]
-                title = data.get("title", "Untitled")
-            # Skip only when there is genuinely nothing to emit: no PDF, and either notes
-            # are disabled or the item has none. With ZOTERO_INCLUDE_NOTES on, note-only
-            # items still surface (build_manifest gives them a notes-only .txt).
-            if not attachments and not (self.include_notes and notes):
+            processed = self._process_item(item)
+            if processed is None:
                 continue
+            item_key, record = processed
             if item_key not in items:
-                items[item_key] = {
-                    "title": title,
-                    "version": item.get("version", data.get("version", 0)),
-                    "paths": [],
-                    "attachments": attachments,
-                    "notes": notes,
-                }
+                items[item_key] = record
             if current_path:
                 if current_path not in items[item_key]["paths"]:
                     items[item_key]["paths"].append(current_path)
@@ -266,6 +252,77 @@ class ZoteroConnector(BaseConnector):
             new_path = f"{current_path}{HIERARCHY_SEP}{sub_name}" if current_path else sub_name
             self._merge(items, self._collect_items(sub["key"], all_collections, new_path))
         return items
+
+    def _collect_unfiled(self) -> dict[str, dict]:
+        """Gather items that live directly in the library, in no collection.
+
+        The collection walk can't see these, and the Zotero API has no "unfiled" query, so
+        fetch every top-level item and keep the ones whose `collections` list is empty. They
+        are all routed into the single virtual self.unfiled_dir directory.
+        """
+        if self._is_excluded(self.unfiled_dir):
+            return {}
+        items: dict[str, dict] = {}
+        for item in self._zot.everything(self._zot.top()):
+            if item.get("data", {}).get("collections"):
+                continue  # filed in at least one collection; the tree walk handles it
+            processed = self._process_item(item)
+            if processed is None:
+                continue
+            item_key, record = processed
+            record["paths"] = [self.unfiled_dir]
+            items[item_key] = record
+        return items
+
+    def _is_excluded(self, path: str) -> bool:
+        """True if `path` equals or sits under any ZOTERO_EXCLUDE entry."""
+        if not path:
+            return False
+        return any(
+            path == ex or path.startswith(f"{ex}{HIERARCHY_SEP}") for ex in self.excluded_paths
+        )
+
+    def _process_item(self, item: dict) -> tuple[str, dict] | None:
+        """Reduce one Zotero item to a manifest record, or None if it has nothing to emit.
+
+        Shared by the collection walk and the unfiled sweep. Returns (item_key, record)
+        with record = {title, version, paths (empty; the caller fills it), attachments,
+        notes}. Returns None for standalone attachments and for items that have neither a
+        PDF nor (when ZOTERO_INCLUDE_NOTES is on) any notes.
+        """
+        data = item.get("data", {})
+        item_type = data.get("itemType")
+        if item_type == "attachment":
+            return None  # standalone attachment, not a parent item
+        item_key = item["key"]
+        if item_type == "note":
+            # A standalone note: it is its own content and has no children.
+            attachments: list[str] = []
+            notes = [self._note_record(item)]
+            title = self._note_title(notes[0]["html"])
+        else:
+            children = self._zot.everything(self._zot.children(item_key))
+            attachments = [
+                c["key"] for c in children if c.get("data", {}).get("itemType") == "attachment"
+            ]
+            notes = [
+                self._note_record(c)
+                for c in children
+                if c.get("data", {}).get("itemType") == "note"
+            ]
+            title = data.get("title", "Untitled")
+        # Skip only when there is genuinely nothing to emit: no PDF, and either notes are
+        # disabled or the item has none. With ZOTERO_INCLUDE_NOTES on, note-only items still
+        # surface (build_manifest gives them a notes-only .txt).
+        if not attachments and not (self.include_notes and notes):
+            return None
+        return item_key, {
+            "title": title,
+            "version": item.get("version", data.get("version", 0)),
+            "paths": [],
+            "attachments": attachments,
+            "notes": notes,
+        }
 
     @staticmethod
     def _merge(dest: dict[str, dict], src: dict[str, dict]) -> None:

--- a/src/oikb/connectors/zotero.py
+++ b/src/oikb/connectors/zotero.py
@@ -21,6 +21,19 @@ Auth and options via env vars:
   ZOTERO_EXCLUDE       ';'-separated collection paths to skip, relative to the synced
                        root and using %% as separator. When syncing
                        "zotero:Research", exclude its subcollections as "Archive;Drafts".
+  ZOTERO_INCLUDE_NOTES        when truthy (1/true/yes/on), append the text of an item's
+                       child notes to its extracted PDF .txt. An item that has notes but no
+                       PDF still surfaces as its own notes-only .txt. Free: notes already
+                       come back with the item's children, so no extra API calls.
+  ZOTERO_INCLUDE_ANNOTATIONS  when truthy, append PDF highlights and comments
+                       (annotationText / annotationComment) to each attachment's .txt. In
+                       'version' checksum mode this costs one extra API call per attachment,
+                       since annotations are children of the attachment, not of the item.
+
+When both are enabled, an attachment's .txt is the PDF body, then a "=== NOTES ==="
+section, then an "=== ANNOTATIONS ===" section. Change detection still works: 'content'
+mode hashes the assembled text, and 'version' mode folds in the note and annotation
+versions (editing a note or annotation bumps its own version, not the item's).
 
 Source syntax: zotero:<hierarchy> where hierarchy uses %% as the separator, e.g.
   zotero:Research%%Machine Learning
@@ -30,6 +43,7 @@ An empty hierarchy (just "zotero:") syncs every top-level collection.
 from __future__ import annotations
 
 import hashlib
+import html
 import os
 import re
 import tempfile
@@ -53,6 +67,8 @@ class ZoteroConnector(BaseConnector):
         api_key: str | None = None,
         checksum: str | None = None,
         exclude: str | None = None,
+        include_notes: bool | None = None,
+        include_annotations: bool | None = None,
     ):
         self.hierarchy = hierarchy
         lib_id = library_id or os.environ.get("ZOTERO_LIBRARY_ID", "")
@@ -72,6 +88,17 @@ class ZoteroConnector(BaseConnector):
         exclude_raw = exclude if exclude is not None else os.environ.get("ZOTERO_EXCLUDE", "")
         self.excluded_paths = {p.strip() for p in exclude_raw.split(";") if p.strip()}
 
+        self.include_notes = (
+            include_notes
+            if include_notes is not None
+            else self._env_flag(os.environ.get("ZOTERO_INCLUDE_NOTES", ""))
+        )
+        self.include_annotations = (
+            include_annotations
+            if include_annotations is not None
+            else self._env_flag(os.environ.get("ZOTERO_INCLUDE_ANNOTATIONS", ""))
+        )
+
         try:
             from pyzotero import zotero
         except ImportError as e:
@@ -80,11 +107,16 @@ class ZoteroConnector(BaseConnector):
             ) from e
         self._zot = zotero.Zotero(lib_id, lib_type, key)
 
-        # (path, filename) -> attachment key, populated during build_manifest.
-        self._index: dict[tuple[str, str], str] = {}
+        # (path, filename) -> record describing what read_file should assemble.
+        # Record: {"attachment": key | None, "notes": [{"key", "version", "html"}]}.
+        # attachment is None for a notes-only file (an item with notes but no PDF).
+        self._index: dict[tuple[str, str], dict] = {}
         # attachment key -> extracted text, so read_file (and content-mode
         # checksumming) never extracts the same attachment twice.
         self._text_cache: dict[str, str] = {}
+        # attachment key -> its annotation items, so we fetch each attachment's
+        # annotations at most once (used by both checksum and read_file).
+        self._annotations_cache: dict[str, list[dict]] = {}
 
     # ── manifest ────────────────────────────────────────────────
 
@@ -106,12 +138,25 @@ class ZoteroConnector(BaseConnector):
 
         entries: list[ManifestEntry] = []
         for item_key, data in items.items():
+            notes = data["notes"] if self.include_notes else []
             for path in data["paths"] or [""]:
                 kb_path = path.replace(HIERARCHY_SEP, "/")
-                for idx, att_key in enumerate(data["attachments"]):
-                    filename = self._unique(kb_path, self._make_filename(data["title"], idx))
-                    checksum, size = self._checksum(item_key, data["version"], att_key)
-                    self._index[(kb_path, filename)] = att_key
+                if data["attachments"]:
+                    for idx, att_key in enumerate(data["attachments"]):
+                        filename = self._unique(kb_path, self._make_filename(data["title"], idx))
+                        checksum, size = self._checksum(item_key, data, att_key)
+                        self._index[(kb_path, filename)] = {"attachment": att_key, "notes": notes}
+                        entries.append(
+                            ManifestEntry(
+                                filename=filename, path=kb_path, checksum=checksum, size=size
+                            )
+                        )
+                elif notes:
+                    # An item with notes but no PDF: surface the notes on their own so
+                    # enabling ZOTERO_INCLUDE_NOTES never silently drops note content.
+                    filename = self._unique(kb_path, self._make_filename(data["title"], 0))
+                    checksum, size = self._checksum(item_key, data, None)
+                    self._index[(kb_path, filename)] = {"attachment": None, "notes": notes}
                     entries.append(
                         ManifestEntry(filename=filename, path=kb_path, checksum=checksum, size=size)
                     )
@@ -120,10 +165,10 @@ class ZoteroConnector(BaseConnector):
         return entries
 
     def read_file(self, path: str, filename: str) -> bytes:
-        att_key = self._index.get((path, filename))
-        if att_key is None:
+        record = self._index.get((path, filename))
+        if record is None:
             raise FileNotFoundError(f"Unknown Zotero file: {path}/{filename}")
-        return self._get_text(att_key).encode("utf-8")
+        return self._assemble(record["attachment"], record["notes"]).encode("utf-8")
 
     # ── collection traversal ────────────────────────────────────
 
@@ -160,8 +205,11 @@ class ZoteroConnector(BaseConnector):
     ) -> dict[str, dict]:
         """Recursively gather items (with attachments) and the paths they appear under.
 
-        Returns a dict: item_key -> {title, version, paths, attachments}. An item that
-        lives in several subcollections records each path it appears under.
+        Returns a dict: item_key -> {title, version, paths, attachments, notes}. An item
+        that lives in several subcollections records each path it appears under. `notes` is
+        the list of the item's child notes (each {key, version, html}); it is populated
+        regardless of self.include_notes so callers can decide, but is only emitted when the
+        flag is on.
         """
         if self.excluded_paths and current_path:
             for ex in self.excluded_paths:
@@ -171,21 +219,38 @@ class ZoteroConnector(BaseConnector):
         items: dict[str, dict] = {}
         for item in self._zot.everything(self._zot.collection_items(collection_key)):
             data = item.get("data", {})
-            if data.get("itemType") == "attachment":
+            item_type = data.get("itemType")
+            if item_type == "attachment":
                 continue  # standalone attachment, not a parent item
             item_key = item["key"]
-            children = self._zot.everything(self._zot.children(item_key))
-            attachments = [
-                c["key"] for c in children if c.get("data", {}).get("itemType") == "attachment"
-            ]
-            if not attachments:
+            if item_type == "note":
+                # A top-level standalone note: it is its own content, has no children.
+                attachments = []
+                notes = [self._note_record(item)]
+                title = self._note_title(notes[0]["html"])
+            else:
+                children = self._zot.everything(self._zot.children(item_key))
+                attachments = [
+                    c["key"] for c in children if c.get("data", {}).get("itemType") == "attachment"
+                ]
+                notes = [
+                    self._note_record(c)
+                    for c in children
+                    if c.get("data", {}).get("itemType") == "note"
+                ]
+                title = data.get("title", "Untitled")
+            # Skip only when there is genuinely nothing to emit: no PDF, and either notes
+            # are disabled or the item has none. With ZOTERO_INCLUDE_NOTES on, note-only
+            # items still surface (build_manifest gives them a notes-only .txt).
+            if not attachments and not (self.include_notes and notes):
                 continue
             if item_key not in items:
                 items[item_key] = {
-                    "title": data.get("title", "Untitled"),
+                    "title": title,
                     "version": item.get("version", data.get("version", 0)),
                     "paths": [],
                     "attachments": attachments,
+                    "notes": notes,
                 }
             if current_path:
                 if current_path not in items[item_key]["paths"]:
@@ -237,11 +302,17 @@ class ZoteroConnector(BaseConnector):
             i += 1
         return f"{stem}__{i}.{ext}"
 
-    def _checksum(self, item_key: str, version: int, attachment_key: str) -> tuple[str, int]:
-        """Return (checksum, size) for an attachment per the configured checksum mode."""
+    def _checksum(self, item_key: str, item: dict, attachment_key: str | None) -> tuple[str, int]:
+        """Return (checksum, size) for one KB file per the configured checksum mode.
+
+        A KB file is a PDF attachment plus, when enabled, the item's notes and the
+        attachment's annotations; the checksum must cover all of them. `attachment_key` is
+        None for a notes-only item.
+        """
+        notes = item["notes"] if self.include_notes else []
         if self.checksum_mode == "content":
             try:
-                data = self._get_text(attachment_key).encode("utf-8")
+                data = self._assemble(attachment_key, notes).encode("utf-8")
                 return hashlib.sha256(data).hexdigest(), len(data)
             except Exception:
                 # Text isn't retrievable (e.g. no file in Zotero storage). Never let one
@@ -249,8 +320,117 @@ class ZoteroConnector(BaseConnector):
                 # checksum so the entry is still created, and the failure surfaces (and is
                 # reported) at upload time through the normal per-file error path.
                 pass
-        digest = hashlib.sha256(f"{item_key}:{version}:{attachment_key}".encode()).hexdigest()
+        # Version mode. Editing a note or annotation bumps its own version, not the parent
+        # item's, so fold those versions in or such edits would go undetected.
+        parts = [item_key, str(item["version"]), attachment_key or ""]
+        if self.include_notes:
+            parts.append("n:" + ",".join(f"{n['key']}={n['version']}" for n in notes))
+        if self.include_annotations and attachment_key is not None:
+            try:
+                anns = self._get_annotations(attachment_key)
+                parts.append("a:" + ",".join(f"{a['key']}={self._version_of(a)}" for a in anns))
+            except Exception:
+                pass  # can't list annotations now; the failure resurfaces at read time
+        digest = hashlib.sha256(":".join(parts).encode()).hexdigest()
         return digest, 0  # size unknown without downloading
+
+    # ── notes & annotations ─────────────────────────────────────
+
+    @staticmethod
+    def _env_flag(raw: str) -> bool:
+        """Interpret an env var as a boolean (1/true/yes/on, case-insensitive)."""
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+
+    @staticmethod
+    def _version_of(item: dict) -> int:
+        """A Zotero item's version, whether it sits at the top level or under 'data'."""
+        return item.get("version", item.get("data", {}).get("version", 0))
+
+    @classmethod
+    def _note_record(cls, item: dict) -> dict:
+        """Reduce a note item to what we need: its key, version, and raw HTML body."""
+        return {
+            "key": item["key"],
+            "version": cls._version_of(item),
+            "html": item.get("data", {}).get("note", ""),
+        }
+
+    @classmethod
+    def _note_title(cls, note_html: str, max_length: int = 60) -> str:
+        """Derive a filename title for a standalone note from its first line of text."""
+        text = cls._html_to_text(note_html)
+        first = next((line.strip() for line in text.splitlines() if line.strip()), "")
+        if not first:
+            return "Untitled"
+        return first[:max_length].strip()
+
+    @staticmethod
+    def _html_to_text(note_html: str) -> str:
+        """Flatten a Zotero note's HTML into plain text (no external dependency)."""
+        if not note_html:
+            return ""
+        s = re.sub(r"(?i)<br\s*/?>", "\n", note_html)
+        s = re.sub(r"(?i)</(p|div|li|h[1-6]|tr|blockquote)>", "\n", s)
+        s = re.sub(r"(?i)<li[^>]*>", "- ", s)
+        s = re.sub(r"<[^>]+>", "", s)  # drop any remaining tags
+        s = html.unescape(s)
+        s = re.sub(r"[ \t]+\n", "\n", s)
+        s = re.sub(r"\n{3,}", "\n\n", s)
+        return s.strip()
+
+    def _assemble(self, attachment_key: str | None, notes: list[dict]) -> str:
+        """Build the .txt body: PDF text, then a notes section, then an annotations section.
+
+        `notes` is empty when ZOTERO_INCLUDE_NOTES is off; annotations are only fetched when
+        ZOTERO_INCLUDE_ANNOTATIONS is on. May raise SourceFileUnavailable if the PDF's bytes
+        can't be fetched (handled upstream as a non-fatal skip).
+        """
+        parts: list[str] = []
+        if attachment_key is not None:
+            parts.append(self._get_text(attachment_key))
+        if notes:
+            body = self._render_notes(notes)
+            if body:
+                parts.append("=== NOTES ===\n" + body)
+        if self.include_annotations and attachment_key is not None:
+            body = self._render_annotations(attachment_key)
+            if body:
+                parts.append("=== ANNOTATIONS ===\n" + body)
+        return "\n\n".join(p for p in parts if p)
+
+    def _render_notes(self, notes: list[dict]) -> str:
+        """Render note records to plain text, one block per note."""
+        blocks = [self._html_to_text(n["html"]) for n in notes]
+        return "\n\n".join(b for b in blocks if b)
+
+    def _get_annotations(self, attachment_key: str) -> list[dict]:
+        """Fetch (and cache) an attachment's annotation items, in reading order."""
+        if attachment_key not in self._annotations_cache:
+            children = self._zot.everything(self._zot.children(attachment_key))
+            anns = [
+                c for c in children if c.get("data", {}).get("itemType") == "annotation"
+            ]
+            anns.sort(key=lambda a: a.get("data", {}).get("annotationSortIndex", ""))
+            self._annotations_cache[attachment_key] = anns
+        return self._annotations_cache[attachment_key]
+
+    def _render_annotations(self, attachment_key: str) -> str:
+        """Render an attachment's highlights/comments to plain text, in reading order."""
+        blocks: list[str] = []
+        for ann in self._get_annotations(attachment_key):
+            data = ann.get("data", {})
+            quote = (data.get("annotationText") or "").strip()
+            comment = (data.get("annotationComment") or "").strip()
+            page = (data.get("annotationPageLabel") or "").strip()
+            prefix = f"[p. {page}] " if page else ""
+            lines: list[str] = []
+            if quote:
+                lines.append(f"{prefix}> {quote}")
+            if comment:
+                lines.append(f"{prefix}{comment}" if not quote else f"  {comment}")
+            if lines:
+                blocks.append("\n".join(lines))
+        return "\n\n".join(blocks)
 
     def _get_text(self, attachment_key: str) -> str:
         """Extract (and cache) the text of a Zotero attachment."""

--- a/src/oikb/daemon.py
+++ b/src/oikb/daemon.py
@@ -335,6 +335,7 @@ async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
             "files_deleted": result.deleted,
             "unmodified": result.unmodified,
             "errors": result.errors or [],
+            "warnings": result.warnings or [],
         }
 
         record_sync(
@@ -373,6 +374,7 @@ async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
             "files_modified": result.modified,
             "files_deleted": result.deleted,
             "errors": result.errors or [],
+            "warnings": result.warnings or [],
         })
 
     except Exception as e:

--- a/src/oikb/sync.py
+++ b/src/oikb/sync.py
@@ -210,7 +210,10 @@ def _run_sync_inner(
     modified: list[dict[str, Any]] = diff.get("modified", [])
     deleted: list[dict[str, Any]] = diff.get("deleted", [])
     unmodified_count: int = diff.get("unmodified_count", 0)
-    mkdir: list[str] = diff.get("mkdir", [])
+    # Sort parent-first: lexicographic order puts "a" before "a/b", so a nested
+    # directory is never created before its parent (whose id we need), and the
+    # dry-run diff lists dirs in a stable, readable order.
+    mkdir: list[str] = sorted(diff.get("mkdir", []))
     rmdir: list[str] = diff.get("rmdir", [])
     directory_map: dict[str, str] = diff.get("directory_map", {})
 

--- a/src/oikb/sync.py
+++ b/src/oikb/sync.py
@@ -21,7 +21,7 @@ from rich.progress import (
 )
 
 from oikb.client import OikbClient
-from oikb.connectors import BaseConnector, ManifestEntry
+from oikb.connectors import BaseConnector, ManifestEntry, SourceFileUnavailable
 
 # Stderr console for progress output (keeps stdout clean for piping).
 _console = Console(stderr=True)
@@ -38,6 +38,9 @@ class SyncResult:
     dirs_created: int = 0
     dirs_removed: int = 0
     errors: list[str] | None = None
+    # Non-fatal skips: files the source advertised but couldn't provide content
+    # for (SourceFileUnavailable). These never fail the run; errors do.
+    warnings: list[str] | None = None
 
     @property
     def total_changes(self) -> int:
@@ -57,6 +60,8 @@ class SyncResult:
             parts.append(f"{self.dirs_created} dirs created")
         if self.dirs_removed:
             parts.append(f"{self.dirs_removed} dirs removed")
+        if self.warnings:
+            parts.append(f"{len(self.warnings)} skipped")
         return ", ".join(parts) if parts else "nothing to do"
 
 
@@ -148,6 +153,7 @@ def run_sync(
     """
     result = SyncResult()
     result.errors = []
+    result.warnings = []
 
     try:
         return _run_sync_inner(
@@ -317,8 +323,15 @@ def _run_sync_inner(
 
     def _upload_one(
         i: int, entry: dict, change_type: str, progress: Progress | None, task_id: Any,
-    ) -> str | None:
-        """Upload a single file with retry. Returns error string or None."""
+    ) -> tuple[str, str | None]:
+        """Upload a single file with retry.
+
+        Returns (status, message):
+          ("added"|"modified", None)  on success
+          ("warning", message)        the source can't provide this file's content
+                                      (SourceFileUnavailable) — skipped, non-fatal
+          ("error", message)          any other failure — fails the run
+        """
         filename = entry["filename"]
         path = entry.get("path", "")
         display = f"{path}/{filename}" if path else filename
@@ -328,7 +341,7 @@ def _run_sync_inner(
 
         manifest_entry = manifest_by_key.get((path, filename))
         if not manifest_entry:
-            return f"File not in manifest: {display}"
+            return ("error", f"File not in manifest: {display}")
 
         last_err: Exception | None = None
         for attempt in range(3):
@@ -344,7 +357,15 @@ def _run_sync_inner(
                 )
                 if progress is not None:
                     progress.update(task_id, advance=1, description=f"[cyan]{display}[/cyan]")
-                return change_type  # success
+                return (change_type, None)  # success
+            except SourceFileUnavailable as e:
+                # Source has no retrievable content for this file. Retrying won't
+                # help; skip it with a warning so it can't fail the whole sync.
+                if progress is not None:
+                    progress.update(task_id, advance=1, description=f"[yellow]⚠ {display}[/yellow]")
+                else:
+                    click.echo(click.style(f"  ⚠ {display}: {e}", fg="yellow"), err=True)
+                return ("warning", f"{display}: {e}")
             except httpx.HTTPStatusError as e:
                 if e.response.status_code >= 500 and attempt < 2:
                     time.sleep(2 ** attempt)
@@ -360,16 +381,19 @@ def _run_sync_inner(
             progress.update(task_id, advance=1, description=f"[red]✗ {display}[/red]")
         else:
             click.echo(click.style(f"  ✗ {display}: {last_err}", fg="red"), err=True)
-        return f"{display}: {last_err}"
+        return ("error", f"{display}: {last_err}")
 
-    def _tally(outcome: str | None) -> None:
+    def _tally(outcome: tuple[str, str | None]) -> None:
         """Update result counters from an upload outcome."""
-        if outcome == "added":
+        status, message = outcome
+        if status == "added":
             result.added += 1
-        elif outcome == "modified":
+        elif status == "modified":
             result.modified += 1
-        elif outcome is not None:
-            result.errors.append(outcome)
+        elif status == "warning":
+            result.warnings.append(message)
+        elif status == "error":
+            result.errors.append(message)
 
     if show_progress:
         progress = Progress(

--- a/tests/test_sync_warnings.py
+++ b/tests/test_sync_warnings.py
@@ -1,0 +1,111 @@
+"""Unavailable source files are non-fatal warnings, every other failure is an error.
+
+Covers the SourceFileUnavailable path end to end:
+  - the Zotero connector maps a missing-file fetch to SourceFileUnavailable
+  - run_sync routes that exception to result.warnings (not result.errors), so a run
+    whose only problems are unavailable files still succeeds
+  - any other read_file() exception still lands in result.errors
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from oikb.connectors import BaseConnector, ManifestEntry, SourceFileUnavailable
+from oikb.sync import run_sync
+
+
+class _FakeClient:
+    """Minimal OikbClient stand-in: marks every manifest file as 'added'."""
+
+    def __init__(self) -> None:
+        self.uploaded: list[str] = []
+
+    def sync_diff(self, kb_id: str, manifest: list[dict]) -> dict:
+        return {
+            "added": [{"filename": e["filename"], "path": e["path"]} for e in manifest],
+            "modified": [],
+            "deleted": [],
+            "unmodified_count": 0,
+            "mkdir": [],
+            "rmdir": [],
+            "directory_map": {},
+        }
+
+    def sync_cleanup(self, *a, **k) -> None:  # pragma: no cover - unused here
+        pass
+
+    def create_directory(self, *a, **k) -> dict:  # pragma: no cover - unused here
+        return {"id": "dir"}
+
+    def upload_file(self, *, filename: str, **k) -> None:
+        self.uploaded.append(filename)
+
+    def close(self) -> None:
+        pass
+
+
+class _Connector(BaseConnector):
+    """Two-file source; reading `bad.txt` raises the exception given at construction."""
+
+    def __init__(self, bad_exc: Exception) -> None:
+        self._bad_exc = bad_exc
+
+    def build_manifest(self) -> list[ManifestEntry]:
+        return [
+            ManifestEntry(filename="good.txt", path="", checksum="h-good", size=4),
+            ManifestEntry(filename="bad.txt", path="", checksum="h-bad", size=0),
+        ]
+
+    def read_file(self, path: str, filename: str) -> bytes:
+        if filename == "bad.txt":
+            raise self._bad_exc
+        return b"data"
+
+
+def _sync(bad_exc: Exception) -> tuple:
+    client = _FakeClient()
+    result = run_sync(client=client, connector=_Connector(bad_exc), kb_id="kb", quiet=True)
+    return client, result
+
+
+def test_unavailable_source_file_is_a_warning_not_an_error():
+    client, result = _sync(SourceFileUnavailable("no downloadable file for ABC123"))
+
+    # The good file uploaded; the unavailable one was skipped, not retried into failure.
+    assert client.uploaded == ["good.txt"]
+    assert result.added == 1
+    assert result.errors == []  # would have been exit 1 in the CLI
+    assert result.warnings and "bad.txt" in result.warnings[0]
+    # Surfaced in the human summary as a skip.
+    assert "1 skipped" in result.summary()
+
+
+def test_other_read_failure_is_still_an_error():
+    client, result = _sync(RuntimeError("connection reset"))
+
+    assert client.uploaded == ["good.txt"]
+    assert result.added == 1
+    assert result.warnings == []
+    assert result.errors and "bad.txt" in result.errors[0]
+
+
+def test_zotero_missing_file_maps_to_sourcefileunavailable():
+    """A Zotero attachment with no fetchable bytes raises SourceFileUnavailable."""
+    from oikb.connectors.zotero import ZoteroConnector
+
+    # Build without __init__ so we don't need real credentials / pyzotero.
+    conn = ZoteroConnector.__new__(ZoteroConnector)
+    conn._text_cache = {}
+
+    class _Zot:
+        def fulltext_item(self, key):
+            raise RuntimeError("not indexed")  # forces the file() fallback
+
+        def file(self, key):
+            raise RuntimeError("Code: 404 Not found")
+
+    conn._zot = _Zot()
+
+    with pytest.raises(SourceFileUnavailable):
+        conn._extract_text("W3PU62BI")

--- a/tests/test_zotero_notes_annotations.py
+++ b/tests/test_zotero_notes_annotations.py
@@ -18,11 +18,16 @@ from oikb.connectors.zotero import ZoteroConnector
 # a PDF attachment, a child note, and a PDF annotation) and one standalone note.
 COLLECTIONS = [{"key": "COLL1", "data": {"name": "Research"}}]
 
-ITEM_ARTICLE = {"key": "IT1", "version": 5, "data": {"itemType": "journalArticle", "title": "Paper A"}}
+# Both top-level items are filed in COLL1 (collections set), so the unfiled sweep skips them.
+ITEM_ARTICLE = {
+    "key": "IT1",
+    "version": 5,
+    "data": {"itemType": "journalArticle", "title": "Paper A", "collections": ["COLL1"]},
+}
 ITEM_STANDALONE_NOTE = {
     "key": "IT2",
     "version": 3,
-    "data": {"itemType": "note", "note": "<p>Standalone thought</p>"},
+    "data": {"itemType": "note", "note": "<p>Standalone thought</p>", "collections": ["COLL1"]},
 }
 ATTACHMENT = {"key": "ATT1", "version": 6, "data": {"itemType": "attachment", "title": "Paper A.pdf"}}
 CHILD_NOTE = {
@@ -46,17 +51,21 @@ ANNOTATION = {
 class _FakeZot:
     """Minimal pyzotero.Zotero stand-in driven by in-memory dicts."""
 
-    def __init__(self, collections, items, children, fulltext):
+    def __init__(self, collections, items, children, fulltext, top=None):
         self._collections = collections
         self._items = items  # collection_key -> [item, ...]
         self._children = children  # parent_key -> [child, ...]
         self._fulltext = fulltext  # attachment_key -> str
+        self._top = top or []  # top-level items across the library (for the unfiled sweep)
 
     def everything(self, x):  # pyzotero pages through generators; our data is already whole
         return x
 
     def collections(self):
         return self._collections
+
+    def top(self):
+        return self._top
 
     def collection_items(self, key):
         return self._items.get(key, [])
@@ -81,7 +90,8 @@ def _make_conn(*, include_notes, include_annotations, checksum_mode="version", o
         overrides(children, items)
 
     conn = ZoteroConnector.__new__(ZoteroConnector)
-    conn._zot = _FakeZot(COLLECTIONS, items, children, {"ATT1": "PDF body text"})
+    # top() returns the library's top-level items; here both are filed in COLL1.
+    conn._zot = _FakeZot(COLLECTIONS, items, children, {"ATT1": "PDF body text"}, top=items["COLL1"])
     conn._index = {}
     conn._text_cache = {}
     conn._annotations_cache = {}
@@ -90,6 +100,7 @@ def _make_conn(*, include_notes, include_annotations, checksum_mode="version", o
     conn.checksum_mode = checksum_mode
     conn.include_notes = include_notes
     conn.include_annotations = include_annotations
+    conn.unfiled_dir = "_unfiled"
     return conn
 
 

--- a/tests/test_zotero_notes_annotations.py
+++ b/tests/test_zotero_notes_annotations.py
@@ -1,0 +1,188 @@
+"""ZOTERO_INCLUDE_NOTES / ZOTERO_INCLUDE_ANNOTATIONS behavior.
+
+Covers the append feature end to end against a fake pyzotero client:
+  - notes (child + standalone) and annotations get appended to the PDF .txt
+  - a note-only item surfaces as its own file only when notes are enabled
+  - both flags off reproduce the old PDF-only behavior
+  - version-mode checksums react to note and annotation version bumps, since
+    editing either bumps its own version, not the parent item's
+"""
+
+from __future__ import annotations
+
+import copy
+
+from oikb.connectors.zotero import ZoteroConnector
+
+# A tiny fake library: one collection "Research" holding a journal article (with
+# a PDF attachment, a child note, and a PDF annotation) and one standalone note.
+COLLECTIONS = [{"key": "COLL1", "data": {"name": "Research"}}]
+
+ITEM_ARTICLE = {"key": "IT1", "version": 5, "data": {"itemType": "journalArticle", "title": "Paper A"}}
+ITEM_STANDALONE_NOTE = {
+    "key": "IT2",
+    "version": 3,
+    "data": {"itemType": "note", "note": "<p>Standalone thought</p>"},
+}
+ATTACHMENT = {"key": "ATT1", "version": 6, "data": {"itemType": "attachment", "title": "Paper A.pdf"}}
+CHILD_NOTE = {
+    "key": "NOTE1",
+    "version": 7,
+    "data": {"itemType": "note", "note": "<p>Great <b>insight</b> here.</p>"},
+}
+ANNOTATION = {
+    "key": "ANN1",
+    "version": 9,
+    "data": {
+        "itemType": "annotation",
+        "annotationText": "highlighted quote",
+        "annotationComment": "my comment",
+        "annotationSortIndex": "00001|00000|00000",
+        "annotationPageLabel": "4",
+    },
+}
+
+
+class _FakeZot:
+    """Minimal pyzotero.Zotero stand-in driven by in-memory dicts."""
+
+    def __init__(self, collections, items, children, fulltext):
+        self._collections = collections
+        self._items = items  # collection_key -> [item, ...]
+        self._children = children  # parent_key -> [child, ...]
+        self._fulltext = fulltext  # attachment_key -> str
+
+    def everything(self, x):  # pyzotero pages through generators; our data is already whole
+        return x
+
+    def collections(self):
+        return self._collections
+
+    def collection_items(self, key):
+        return self._items.get(key, [])
+
+    def children(self, key):
+        return self._children.get(key, [])
+
+    def fulltext_item(self, key):
+        if key in self._fulltext:
+            return {"content": self._fulltext[key]}
+        raise RuntimeError("not indexed")
+
+
+def _make_conn(*, include_notes, include_annotations, checksum_mode="version", overrides=None):
+    """Build a ZoteroConnector wired to the fake library, bypassing __init__/creds."""
+    children = {
+        "IT1": [copy.deepcopy(ATTACHMENT), copy.deepcopy(CHILD_NOTE)],
+        "ATT1": [copy.deepcopy(ANNOTATION)],
+    }
+    items = {"COLL1": [copy.deepcopy(ITEM_ARTICLE), copy.deepcopy(ITEM_STANDALONE_NOTE)]}
+    if overrides:
+        overrides(children, items)
+
+    conn = ZoteroConnector.__new__(ZoteroConnector)
+    conn._zot = _FakeZot(COLLECTIONS, items, children, {"ATT1": "PDF body text"})
+    conn._index = {}
+    conn._text_cache = {}
+    conn._annotations_cache = {}
+    conn.excluded_paths = set()
+    conn.hierarchy = None
+    conn.checksum_mode = checksum_mode
+    conn.include_notes = include_notes
+    conn.include_annotations = include_annotations
+    return conn
+
+
+def _read(conn, display_path):
+    if not conn._index:  # read_file resolves against the index that build_manifest fills
+        conn.build_manifest()
+    path, _, filename = display_path.rpartition("/")
+    return conn.read_file(path, filename).decode("utf-8")
+
+
+def test_flags_off_is_pdf_only_and_skips_note_only_items():
+    conn = _make_conn(include_notes=False, include_annotations=False)
+    manifest = conn.build_manifest()
+
+    paths = [e.display_path for e in manifest]
+    # Only the article's PDF; the standalone note is not emitted.
+    assert paths == ["Research/Paper A.txt"]
+    assert _read(conn, "Research/Paper A.txt") == "PDF body text"
+
+
+def test_notes_and_annotations_are_appended_to_pdf_text():
+    conn = _make_conn(include_notes=True, include_annotations=True)
+    manifest = conn.build_manifest()
+    paths = {e.display_path for e in manifest}
+
+    # The article PDF plus the standalone note as its own file.
+    assert "Research/Paper A.txt" in paths
+    assert "Research/Standalone thought.txt" in paths
+
+    body = _read(conn, "Research/Paper A.txt")
+    assert body == (
+        "PDF body text\n\n"
+        "=== NOTES ===\n"
+        "Great insight here.\n\n"
+        "=== ANNOTATIONS ===\n"
+        "[p. 4] > highlighted quote\n"
+        "  my comment"
+    )
+
+
+def test_note_only_item_surfaces_as_its_own_file():
+    conn = _make_conn(include_notes=True, include_annotations=False)
+    assert _read(conn, "Research/Standalone thought.txt") == "=== NOTES ===\nStandalone thought"
+
+
+def test_annotations_disabled_leaves_them_out():
+    conn = _make_conn(include_notes=True, include_annotations=False)
+    body = _read(conn, "Research/Paper A.txt")
+    assert "=== NOTES ===" in body
+    assert "=== ANNOTATIONS ===" not in body
+    assert "highlighted quote" not in body
+
+
+def test_notes_disabled_leaves_them_out_but_keeps_annotations():
+    conn = _make_conn(include_notes=False, include_annotations=True)
+    body = _read(conn, "Research/Paper A.txt")
+    assert "=== NOTES ===" not in body
+    assert "=== ANNOTATIONS ===" in body
+
+
+def _checksum_for(conn, display_path):
+    entry = next(e for e in conn.build_manifest() if e.display_path == display_path)
+    return entry.checksum
+
+
+def test_version_checksum_reacts_to_note_edit():
+    """Editing a note bumps only the note's version, so the checksum must still change."""
+    base = _make_conn(include_notes=True, include_annotations=True)
+    baseline = _checksum_for(base, "Research/Paper A.txt")
+
+    def bump_note(children, items):
+        children["IT1"][1]["version"] = 8  # was 7
+
+    edited = _make_conn(include_notes=True, include_annotations=True, overrides=bump_note)
+    assert _checksum_for(edited, "Research/Paper A.txt") != baseline
+
+
+def test_version_checksum_reacts_to_annotation_edit():
+    """Editing an annotation bumps only the annotation's version; checksum must change."""
+    base = _make_conn(include_notes=True, include_annotations=True)
+    baseline = _checksum_for(base, "Research/Paper A.txt")
+
+    def bump_ann(children, items):
+        children["ATT1"][0]["version"] = 10  # was 9
+
+    edited = _make_conn(include_notes=True, include_annotations=True, overrides=bump_ann)
+    assert _checksum_for(edited, "Research/Paper A.txt") != baseline
+
+
+def test_content_checksum_covers_appended_sections():
+    """In content mode the checksum hashes the assembled text, so appended notes shift it."""
+    without = _make_conn(include_notes=False, include_annotations=False, checksum_mode="content")
+    with_notes = _make_conn(include_notes=True, include_annotations=True, checksum_mode="content")
+    assert _checksum_for(without, "Research/Paper A.txt") != _checksum_for(
+        with_notes, "Research/Paper A.txt"
+    )

--- a/tests/test_zotero_unfiled.py
+++ b/tests/test_zotero_unfiled.py
@@ -1,0 +1,133 @@
+"""Unfiled 'My Library' items (in no collection) get swept into a virtual directory.
+
+A whole-library sync (bare ``zotero:``) must surface items that sit directly in the library
+with no collection, since the collection-tree walk can't see them. A named-hierarchy sync
+must not. Covers directory naming/override, that filed items aren't duplicated, and that the
+unfiled directory can be excluded.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from oikb.connectors.zotero import ZoteroConnector
+
+# One collection "Research" with a filed article, plus two items that sit directly in the
+# library (empty `collections`): a loose PDF item and a loose standalone note.
+COLLECTIONS = [{"key": "COLL1", "data": {"name": "Research"}}]
+
+FILED_ARTICLE = {
+    "key": "IT_FILED",
+    "version": 5,
+    "data": {"itemType": "journalArticle", "title": "Filed Paper", "collections": ["COLL1"]},
+}
+UNFILED_ARTICLE = {
+    "key": "IT_LOOSE",
+    "version": 9,
+    "data": {"itemType": "journalArticle", "title": "Loose Paper", "collections": []},
+}
+UNFILED_NOTE = {
+    "key": "IT_NOTE",
+    "version": 4,
+    "data": {"itemType": "note", "note": "<p>A loose thought</p>", "collections": []},
+}
+
+CHILDREN = {
+    "IT_FILED": [{"key": "ATT_F", "version": 6, "data": {"itemType": "attachment"}}],
+    "IT_LOOSE": [{"key": "ATT_L", "version": 8, "data": {"itemType": "attachment"}}],
+}
+FULLTEXT = {"ATT_F": "filed body", "ATT_L": "loose body"}
+
+
+class _FakeZot:
+    def __init__(self, *, top):
+        self._top = top
+
+    def everything(self, x):
+        return x
+
+    def collections(self):
+        return COLLECTIONS
+
+    def top(self):
+        return self._top
+
+    def collection_items(self, key):
+        return [copy.deepcopy(FILED_ARTICLE)] if key == "COLL1" else []
+
+    def children(self, key):
+        return copy.deepcopy(CHILDREN.get(key, []))
+
+    def fulltext_item(self, key):
+        return {"content": FULLTEXT[key]}
+
+
+def _make_conn(*, hierarchy, include_notes=False, exclude=None, unfiled_dir="_unfiled"):
+    conn = ZoteroConnector.__new__(ZoteroConnector)
+    conn._zot = _FakeZot(
+        top=[copy.deepcopy(FILED_ARTICLE), copy.deepcopy(UNFILED_ARTICLE), copy.deepcopy(UNFILED_NOTE)]
+    )
+    conn._index = {}
+    conn._text_cache = {}
+    conn._annotations_cache = {}
+    conn.excluded_paths = set(exclude or [])
+    conn.hierarchy = hierarchy
+    conn.checksum_mode = "version"
+    conn.include_notes = include_notes
+    conn.include_annotations = False
+    conn.unfiled_dir = unfiled_dir
+    return conn
+
+
+def _paths(conn):
+    return sorted(e.display_path for e in conn.build_manifest())
+
+
+def test_bare_sync_sweeps_unfiled_items():
+    conn = _make_conn(hierarchy=None, include_notes=True)
+    paths = _paths(conn)
+
+    # Filed item stays under its collection; loose items land under _unfiled/.
+    assert "Research/Filed Paper.txt" in paths
+    assert "_unfiled/Loose Paper.txt" in paths
+    assert "_unfiled/A loose thought.txt" in paths  # note-only, enabled via include_notes
+
+    # The loose PDF's content is its extracted body.
+    assert conn.read_file("_unfiled", "Loose Paper.txt").decode() == "loose body"
+
+
+def test_named_hierarchy_never_includes_unfiled():
+    conn = _make_conn(hierarchy="Research", include_notes=True)
+    paths = _paths(conn)
+
+    assert paths == ["Filed Paper.txt"]  # synced root is the collection; no _unfiled sweep
+    assert not any(p.startswith("_unfiled/") for p in paths)
+
+
+def test_filed_items_are_not_duplicated_into_unfiled():
+    """An item in a collection is top-level too, but its non-empty `collections` excludes it."""
+    conn = _make_conn(hierarchy=None)
+    paths = _paths(conn)
+    assert paths.count("Research/Filed Paper.txt") == 1
+    assert not any("Filed Paper" in p and p.startswith("_unfiled/") for p in paths)
+
+
+def test_note_only_unfiled_item_needs_include_notes():
+    conn = _make_conn(hierarchy=None, include_notes=False)
+    paths = _paths(conn)
+    # The loose PDF still appears, but the loose note does not without the flag.
+    assert "_unfiled/Loose Paper.txt" in paths
+    assert not any("loose thought" in p for p in paths)
+
+
+def test_unfiled_dir_is_configurable():
+    conn = _make_conn(hierarchy=None, unfiled_dir="Inbox")
+    paths = _paths(conn)
+    assert "Inbox/Loose Paper.txt" in paths
+    assert not any(p.startswith("_unfiled/") for p in paths)
+
+
+def test_unfiled_dir_can_be_excluded():
+    conn = _make_conn(hierarchy=None, include_notes=True, exclude={"_unfiled"})
+    paths = _paths(conn)
+    assert paths == ["Research/Filed Paper.txt"]  # every unfiled entry dropped


### PR DESCRIPTION
## Summary

Adds a **Zotero** connector to oikb. It syncs the text of the PDF attachments of items in a Zotero collection (and its subcollections) into an Open WebUI Knowledge Base, mapping the Zotero collection hierarchy onto KB directories. It is read-only with respect to Zotero: it never modifies, deletes, or adds anything to the library.

This is a Claude Code port of an earlier standalone tool I wrote, https://github.com/thiswillbeyourgithub/openwebui-knowledge-zotero-sync, reworked to fit oikb's connector interface.

## Zotero connector

- New `zotero:<hierarchy>` source scheme. `%%` separates collection names
  (e.g. `zotero:Research%%Machine Learning`); a bare `zotero:` syncs every top-level collection.
- Text extraction prefers Zotero's indexed fulltext API, falling back to PyMuPDF on the downloaded PDF.
- Collection hierarchy maps to KB directories; an item that lives in several  subcollections is handled.
- Change detection via `ZOTERO_CHECKSUM`: `version` (cheap, hashes the Zotero item version, no download, default) or `content` (hashes the extracted text).
- `ZOTERO_EXCLUDE` skips subcollections, relative to the synced root.
- Auth/options via env: `ZOTERO_LIBRARY_ID`, `ZOTERO_API_KEY`, `ZOTERO_LIBRARY_TYPE`,  `ZOTERO_CHECKSUM`, `ZOTERO_EXCLUDE`.
- Optional dependency group: `pip install oikb[zotero]` (pyzotero + pymupdf).
- README and docs/guide.md updated.

## Sync change: unavailable source files are warnings, not fatal errors

A file the source advertises in its manifest but cannot provide content for (e.g. a Zotero attachment whose bytes aren't in storage: a web link, a linked file, or a WebDAV-only item) is a source-side data gap, not an oikb failure. Previously any such case landed in `result.errors` and exited the whole sync with code 1.

This PR adds a `SourceFileUnavailable` exception to the connector base. `run_sync` catches it specifically (no retry) and routes the file to a new `result.warnings`
list instead of `result.errors`, so a sync whose only problems are unavailable source files still succeeds (exit 0). Any other `read_file()` exception still fails the run exactly as before. The CLI and daemon surface warnings separately from errors; only `result.errors` affects the exit code / success status.

## Tests

`tests/test_sync_warnings.py` covers all three paths: the Zotero missing-file mapping to `SourceFileUnavailable`, warning routing in `run_sync`, and that a generic read failure is still an error.

## Notes

- Opening as a draft for early feedback on the connector shape and on whether the warnings-vs-errors sync change is acceptable as written.
- Implemented with Claude Code.
- I initially wanted to add support for using only the yaml instead of env variables to simplify setup but it resuired some fundamental changes I felt could go beyond the scope of a single PR. Let me know if you'd like me to streamline this.