### PR TITLE
Updated sharepoint to make use of redirect 302 responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ build/
 .eggs/
 *.egg
 .pytest_cache/
+.env
 .DS_Store
 Thumbs.db
 uv.lock
+.yaml
+.oikb.yaml

--- a/src/oikb/connectors/sharepoint.py
+++ b/src/oikb/connectors/sharepoint.py
@@ -86,6 +86,7 @@ class SharePointConnector(BaseConnector):
             base_url="https://graph.microsoft.com/v1.0",
             headers={"Authorization": f"Bearer {access_token}"},
             timeout=60.0,
+            follow_redirects=True,
         )
 
         # Resolve site ID.

--- a/src/oikb/connectors/sharepoint.py
+++ b/src/oikb/connectors/sharepoint.py
@@ -133,7 +133,10 @@ class SharePointConnector(BaseConnector):
 
     def read_file(self, path: str, filename: str) -> bytes:
         file_path = f"{path}/{filename}" if path else filename
-        resp = self._http.get(f"/drives/{self._drive_id}/root:/{file_path}:/content")
+        resp = self._http.get(
+            f"/drives/{self._drive_id}/root:/{file_path}:/content",
+            follow_redirects=True,
+        )
         resp.raise_for_status()
         return resp.content
 

--- a/src/oikb/history.py
+++ b/src/oikb/history.py
@@ -45,7 +45,7 @@ class SyncHistory:
 
     def _get_conn(self) -> sqlite3.Connection:
         if self._conn is None:
-            self._conn = sqlite3.connect(str(self.db_path))
+            self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
             self._conn.row_factory = sqlite3.Row
             self._conn.executescript(_SCHEMA)
         return self._conn


### PR DESCRIPTION
Found a bug 
```2026-06-30T09:01:21.396450861Z   ✗ Project Management/Team Onboarding.pdf: Redirect response '302 Found' for url 'https://graph.microsoft.com/v1.0/drives/xxxxxx/root:/Project%20Management/Team%20Onboarding.pdf:/content'

[owui-oikb-sharepoint-sync] 2026-06-30T09:01:21.396464165Z Redirect location: 'https://x.sharepoint.com/_layouts/15/download.aspx?UniqueId=xxxxx&ApiVersion=2.0'```