### PR TITLE
fix: support Google Shared Drives in gdrive connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Google Drive**: sync now works for folders inside a Shared Drive (formerly Team Drive). The Drive API `files.list` calls were missing `supportsAllDrives` and `includeItemsFromAllDrives`, so Shared Drive contents were invisible and the sync reported "nothing to do". File downloads/exports now pass `supportsAllDrives` as well.
+
 ## [0.3.6] - 2026-05-28
 
 ### Added

--- a/src/oikb/connectors/gdrive.py
+++ b/src/oikb/connectors/gdrive.py
@@ -91,6 +91,8 @@ class GDriveConnector(BaseConnector):
                     fields="nextPageToken, files(id, name, mimeType, md5Checksum, modifiedTime, size)",
                     pageSize=1000,
                     pageToken=page_token,
+                    supportsAllDrives=True,
+                    includeItemsFromAllDrives=True,
                 )
                 .execute()
             )
@@ -140,14 +142,26 @@ class GDriveConnector(BaseConnector):
             raise FileNotFoundError(f"File not found in Drive: {path}/{filename}")
 
         # Check if it needs export.
-        meta = self._service.files().get(fileId=file_id, fields="mimeType").execute()
+        meta = (
+            self._service.files()
+            .get(fileId=file_id, fields="mimeType", supportsAllDrives=True)
+            .execute()
+        )
         mime = meta["mimeType"]
 
         if mime in _EXPORT_MIMES:
             export_mime, _ = _EXPORT_MIMES[mime]
-            return self._service.files().export(fileId=file_id, mimeType=export_mime).execute()
+            return (
+                self._service.files()
+                .export(fileId=file_id, mimeType=export_mime)
+                .execute()
+            )
 
-        return self._service.files().get_media(fileId=file_id).execute()
+        return (
+            self._service.files()
+            .get_media(fileId=file_id, supportsAllDrives=True)
+            .execute()
+        )
 
     def _find_file(self, path: str, filename: str) -> str | None:
         """Find a file ID by navigating the folder path."""
@@ -168,6 +182,8 @@ class GDriveConnector(BaseConnector):
                     .list(
                         q=f"'{current_folder}' in parents and name = '{segment}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false",
                         fields="files(id)",
+                        supportsAllDrives=True,
+                        includeItemsFromAllDrives=True,
                     )
                     .execute()
                 )
@@ -182,6 +198,8 @@ class GDriveConnector(BaseConnector):
             .list(
                 q=f"'{current_folder}' in parents and name = '{search_name}' and trashed = false",
                 fields="files(id)",
+                supportsAllDrives=True,
+                includeItemsFromAllDrives=True,
             )
             .execute()
         )


### PR DESCRIPTION
## Summary

Fixes #52 — the `gdrive` connector reported "nothing to do" when the target folder lives inside a Google **Shared Drive** (formerly Team Drive), even with correct service-account permissions.

The Drive API's `files.list` does not return items from Shared Drives unless the request opts in with `supportsAllDrives=True` and `includeItemsFromAllDrives=True`. Personal "My Drive" folders work because they don't require these flags — which is why the connector worked in that case but silently returned an empty listing for Shared Drives.

## Changes

`src/oikb/connectors/gdrive.py`:
- Add `supportsAllDrives=True` and `includeItemsFromAllDrives=True` to all `files.list` calls — one in `_walk_folder()` and both in `_find_file()`.
- Pass `supportsAllDrives=True` to `files.get` and `files.get_media` in `read_file()` so Shared Drive files can be downloaded. (`files.export` accepts only `fileId`/`mimeType` and works by ID, so it is left unchanged.)

The flags are a no-op for My Drive folders, so existing behaviour is unchanged.

## Testing

- `python -m py_compile src/oikb/connectors/gdrive.py` passes.
- Manual: with a service account granted access to a Shared Drive folder, `oikb diff gdrive:<shared-drive-folder-id> --kb-id <kb>` now lists files instead of reporting "nothing to do".

🤖 Generated with [Claude Code](https://claude.com/claude-code)