### PR TITLE
fix(history): give each thread its own SQLite connection (fixes #39)

### DIFF
--- a/src/oikb/history.py
+++ b/src/oikb/history.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -41,14 +42,25 @@ class SyncHistory:
     def __init__(self, db_path: Path | None = None):
         self.db_path = db_path or _DEFAULT_DB
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn: sqlite3.Connection | None = None
+        # One connection per thread. The daemon runs each sync through
+        # asyncio.to_thread(), so a single shared connection is handed to whichever
+        # pool thread happens to run the next source -- and sqlite3 refuses it with
+        # "SQLite objects created in a thread can only be used in that same thread",
+        # failing every source but the first.
+        self._local = threading.local()
 
     def _get_conn(self) -> sqlite3.Connection:
-        if self._conn is None:
-            self._conn = sqlite3.connect(str(self.db_path))
-            self._conn.row_factory = sqlite3.Row
-            self._conn.executescript(_SCHEMA)
-        return self._conn
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(str(self.db_path), timeout=30.0)
+            conn.row_factory = sqlite3.Row
+            # WAL lets the concurrent sources read while one writes; the busy timeout
+            # makes the brief write-lock contention wait rather than raise.
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=30000")
+            conn.executescript(_SCHEMA)
+            self._local.conn = conn
+        return conn
 
     def log(
         self,
@@ -133,6 +145,12 @@ class SyncHistory:
         return cursor.rowcount
 
     def close(self) -> None:
-        if self._conn:
-            self._conn.close()
-            self._conn = None
+        """Close this thread's connection, if it has one.
+
+        Connections are per-thread, so each thread closes its own; the others are
+        released when their thread exits.
+        """
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is not None:
+            conn.close()
+            self._local.conn = None


### PR DESCRIPTION
Fixes #39.

## The bug

`SyncHistory` caches a single `sqlite3.Connection` in `self._conn`, created lazily by whichever thread calls `_get_conn()` first. The daemon runs every sync through `asyncio.to_thread()`, so the next source lands on a *different* pool thread — and `sqlite3` (with its default `check_same_thread=True`) refuses it:

```
SQLite objects created in a thread can only be used in that same thread.
```

The first source to finish wins the connection and succeeds; **every other source raises.** That matches #39's report exactly (4 of 5 sources failing), and it is connector-agnostic — #39 hit it with Google Drive, I hit it with `outline:` on 4 sources.

### Why it's worse than it looks

`SyncHistory.log()` is called *after* `run_sync()` has already uploaded, and `_run_entry_locked()` catches the exception in its broad `except Exception` — which overwrites the just-set success state:

```python
_scheduler_state[source] = { "status": status, "files_added": result.added, ... }  # success
...
await asyncio.to_thread(_history.log, ...)   # <-- raises here
except Exception as e:
    _scheduler_state[source] = {"status": "error", "error": str(e)}   # success is discarded
```

So the documents **do** reach the knowledge base, while `/health`, the dashboard and the history all report `error` for a sync that actually worked. Anything monitoring the daemon is permanently red, and the counts (`files_added`, etc.) are lost.

## The fix

Hold the connection in a `threading.local()` so each thread gets its own. Also open with WAL and a busy timeout, so the now-genuinely-concurrent writers wait on the brief write lock instead of raising `database is locked`.

One file, no API change.

## Reproduction

Against `main`, driving `SyncHistory` the way the daemon does:

```python
h = SyncHistory(db_path=db)
async def log(i):
    await asyncio.to_thread(h.log, source=f"src{i}", kb_id=f"kb{i}",
                            status="success", started_at=0.0, files_added=1)
await asyncio.gather(*(log(i) for i in range(5)), return_exceptions=True)
```

**Before:** 4 of 5 raise `ProgrammingError: SQLite objects created in a thread...`, and the follow-up `query()` raises too.
**After:** `sources logged OK: 5/5`, `rows in history: 5`.

Also re-checked the single-threaded CLI path — `log`, `query` (plain / `errors_only` / `kb_id`), `last_sync`, `clear`, and a double `close()` — all unchanged.