### PR TITLE
feat(bookstack): use native markdown export for pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- **BookStack**: use BookStack's native Markdown export for synced pages.
+
 ## [0.3.6] - 2026-05-28
 
 ### Added

--- a/src/oikb/connectors/bookstack.py
+++ b/src/oikb/connectors/bookstack.py
@@ -1,4 +1,4 @@
-"""BookStack connector — sync pages from a BookStack instance.
+"""BookStack connector — sync pages from a BookStack instance as Markdown.
 
 Auth via BOOKSTACK_URL, BOOKSTACK_TOKEN_ID, BOOKSTACK_TOKEN_SECRET env vars.
 """
@@ -15,7 +15,7 @@ from oikb.connectors import BaseConnector, ManifestEntry
 
 
 class BookStackConnector(BaseConnector):
-    """Sync pages from BookStack."""
+    """Sync pages from BookStack via its native Markdown export."""
 
     def __init__(self, base_url: str | None = None, token_id: str | None = None, token_secret: str | None = None):
         self._url = (base_url or os.environ.get("BOOKSTACK_URL", "")).rstrip("/")
@@ -35,7 +35,7 @@ class BookStackConnector(BaseConnector):
             data = resp.json()
             for page in data.get("data", []):
                 title = re.sub(r'[<>:"/\\|?*]', "_", page.get("name", "Untitled"))
-                filename = f"{page['id']}_{title[:50]}.txt"
+                filename = f"{page['id']}_{title[:50]}.md"
                 checksum = hashlib.sha256(f"{page['id']}:{page.get('updated_at', '')}".encode()).hexdigest()[:16]
                 entries.append(ManifestEntry(filename=filename, path="", checksum=checksum, size=0))
             if len(data.get("data", [])) < 100:
@@ -46,11 +46,9 @@ class BookStackConnector(BaseConnector):
 
     def read_file(self, path: str, filename: str) -> bytes:
         page_id = filename.split("_")[0]
-        resp = self._http.get(f"/api/pages/{page_id}")
+        resp = self._http.get(f"/api/pages/{page_id}/export/markdown")
         resp.raise_for_status()
-        data = resp.json()
-        text = f"# {data.get('name', '')}\n\n{re.sub(r'<[^>]+>', ' ', data.get('html', ''))}"
-        return text.encode("utf-8")
+        return resp.content
 
     def close(self) -> None:
         self._http.close()


### PR DESCRIPTION
## Summary

Switches the BookStack connector from plain text output to BookStack's native Markdown page export.

BookStack synced pages now use `.md` files backed by:

`GET /api/pages/{id}/export/markdown`

## Why

The connector previously fetched page HTML and stripped tags with a simple regex before uploading `.txt` files. This lost useful document structure such as headings, lists, links, code blocks, and tables.

BookStack provides a native Markdown export endpoint for pages, which preserves more structure and is better suited for Knowledge Base ingestion.

## Changes

- Use `.md` filenames for BookStack synced pages.
- Fetch page content from BookStack's native Markdown export endpoint.
- Remove the manual HTML-to-text regex conversion.
- Document the behavior change in `CHANGELOG.md`.

## Validation

- `python3 -m compileall src/oikb/connectors/bookstack.py`
- Tested against a running BookStack/oikb container by patching the connector in-place and confirming Markdown export sync works.

## Notes

Existing BookStack `.txt` entries may be replaced by `.md` entries on the next sync because the exported file extension changes.