### PR TITLE
feat(bookstack): add configurable export options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **BookStack**: support configurable sync scope, export output, format, and flat or hierarchical structure.
+
 ## [0.3.6] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **BookStack**: support configurable sync scope, export output, format, and flat or hierarchical structure.
+- **BookStack**: support scope paths, include/exclude ID filters, chapter/book/page export output, format selection, and flat or hierarchical structure.
 
 ## [0.3.6] - 2026-05-28
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -256,6 +256,7 @@ Requires `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, and `CONFLUENCE_API_TOKEN`.
 ```bash
 oikb sync bookstack: --kb-id your-kb-id
 oikb sync 'bookstack:12?scope=pages' --kb-id your-kb-id
+oikb sync 'bookstack:12?scope=books&output=chapters' --kb-id your-kb-id
 oikb sync 'bookstack:12?scope=books&output=books&format=pdf' --kb-id your-kb-id
 oikb sync 'bookstack:5?scope=shelves&structure=hierarchical' --kb-id your-kb-id
 ```
@@ -266,9 +267,13 @@ Defaults are `scope=books`, `output=pages`, `format=md`, and `structure=flat`.
 | Parameter | Values | Description |
 |---|---|---|
 | `scope` | `pages`, `books`, `shelves` | Selects what the IDs refer to. |
-| `output` | `pages`, `books` | Exports individual pages or whole books. `scope=pages` always uses page output. |
+| `output` | `pages`, `chapters`, `books` | Exports individual pages, chapters where pages are grouped in chapters, or whole books. |
 | `format` | `txt`, `md`, `html`, `pdf` | Exported file format. |
 | `structure` | `flat`, `hierarchical` | Keeps files flat or mirrors shelf/book/chapter paths where available. |
+
+When `scope=pages` is used, `output` is always treated as `pages`.
+
+With `output=chapters`, pages outside chapters remain individual page exports.
 
 ### Cloud Storage (S3 / GCS / Azure)
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -254,10 +254,19 @@ Requires `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, and `CONFLUENCE_API_TOKEN`.
 ### BookStack
 
 ```bash
+# Sync all pages from all BookStack books as Markdown files.
 oikb sync bookstack: --kb-id your-kb-id
+
+# Sync one specific BookStack page.
 oikb sync 'bookstack:12?scope=pages' --kb-id your-kb-id
+
+# Sync one BookStack book as chapter files; pages outside chapters remain page files.
 oikb sync 'bookstack:12?scope=books&output=chapters' --kb-id your-kb-id
+
+# Sync one whole BookStack book as a PDF file.
 oikb sync 'bookstack:12?scope=books&output=books&format=pdf' --kb-id your-kb-id
+
+# Sync all pages from one shelf and preserve shelf/book/chapter paths.
 oikb sync 'bookstack:5?scope=shelves&structure=hierarchical' --kb-id your-kb-id
 ```
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -20,6 +20,7 @@ A complete guide to syncing content into Open WebUI Knowledge Bases.
   - [GitHub](#github)
   - [GitLab / Bitbucket](#gitlab--bitbucket)
   - [Confluence](#confluence)
+  - [BookStack](#bookstack)
   - [Cloud Storage (S3 / GCS / Azure)](#cloud-storage-s3--gcs--azure)
   - [SharePoint](#sharepoint)
   - [Nextcloud](#nextcloud)
@@ -249,6 +250,25 @@ oikb sync confluence:SPACE_KEY --kb-id your-kb-id
 ```
 
 Requires `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, and `CONFLUENCE_API_TOKEN`.
+
+### BookStack
+
+```bash
+oikb sync bookstack: --kb-id your-kb-id
+oikb sync 'bookstack:12?scope=pages' --kb-id your-kb-id
+oikb sync 'bookstack:12?scope=books&output=books&format=pdf' --kb-id your-kb-id
+oikb sync 'bookstack:5?scope=shelves&structure=hierarchical' --kb-id your-kb-id
+```
+
+Requires `BOOKSTACK_URL`, `BOOKSTACK_TOKEN_ID`, and `BOOKSTACK_TOKEN_SECRET`.
+Defaults are `scope=books`, `output=pages`, `format=md`, and `structure=flat`.
+
+| Parameter | Values | Description |
+|---|---|---|
+| `scope` | `pages`, `books`, `shelves` | Selects what the IDs refer to. |
+| `output` | `pages`, `books` | Exports individual pages or whole books. `scope=pages` always uses page output. |
+| `format` | `txt`, `md`, `html`, `pdf` | Exported file format. |
+| `structure` | `flat`, `hierarchical` | Keeps files flat or mirrors shelf/book/chapter paths where available. |
 
 ### Cloud Storage (S3 / GCS / Azure)
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -258,29 +258,32 @@ Requires `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, and `CONFLUENCE_API_TOKEN`.
 oikb sync bookstack: --kb-id your-kb-id
 
 # Sync one specific BookStack page.
-oikb sync 'bookstack:12?scope=pages' --kb-id your-kb-id
+oikb sync 'bookstack:pages?include_ids=12' --kb-id your-kb-id
 
 # Sync one BookStack book as chapter files; pages outside chapters remain page files.
-oikb sync 'bookstack:12?scope=books&output=chapters' --kb-id your-kb-id
+oikb sync 'bookstack:books?include_ids=12&output=chapters' --kb-id your-kb-id
 
 # Sync one whole BookStack book as a PDF file.
-oikb sync 'bookstack:12?scope=books&output=books&format=pdf' --kb-id your-kb-id
+oikb sync 'bookstack:books?include_ids=12&output=books&format=pdf' --kb-id your-kb-id
 
 # Sync all pages from one shelf and preserve shelf/book/chapter paths.
-oikb sync 'bookstack:5?scope=shelves&structure=hierarchical' --kb-id your-kb-id
+oikb sync 'bookstack:shelves?include_ids=5&structure=hierarchical' --kb-id your-kb-id
 ```
 
 Requires `BOOKSTACK_URL`, `BOOKSTACK_TOKEN_ID`, and `BOOKSTACK_TOKEN_SECRET`.
-Defaults are `scope=books`, `output=pages`, `format=md`, and `structure=flat`.
+Defaults are `bookstack:books`, `output=pages`, `format=md`, and `structure=flat`.
+
+Use `bookstack:pages`, `bookstack:books`, or `bookstack:shelves` to select what IDs refer to. `bookstack:` defaults to `bookstack:books`.
 
 | Parameter | Values | Description |
 |---|---|---|
-| `scope` | `pages`, `books`, `shelves` | Selects what the IDs refer to. |
 | `output` | `pages`, `chapters`, `books` | Exports individual pages, chapters where pages are grouped in chapters, or whole books. |
 | `format` | `txt`, `md`, `html`, `pdf` | Exported file format. |
 | `structure` | `flat`, `hierarchical` | Keeps files flat or mirrors shelf/book/chapter paths where available. |
+| `include_ids` | comma-separated IDs | Limits the selected pages, books, or shelves. |
+| `exclude_ids` | comma-separated IDs | Excludes selected pages, books, or shelves. |
 
-When `scope=pages` is used, `output` is always treated as `pages`.
+When `bookstack:pages` is used, `output` is always treated as `pages`.
 
 With `output=chapters`, pages outside chapters remain individual page exports.
 

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -161,8 +161,15 @@ def _resolve_connector(source: str, branch: str | None = None, path: str | None 
         return SalesforceConnector()
 
     if source.startswith("bookstack:"):
-        from oikb.connectors.bookstack import BookStackConnector
-        return BookStackConnector()
+        from oikb.connectors.bookstack import BookStackConnector, parse_bookstack_source
+        parsed = parse_bookstack_source(source)
+        return BookStackConnector(
+            ids=parsed["ids"],
+            scope=parsed["scope"],
+            export_output=parsed["output"],
+            export_format=parsed["format"],
+            structure=parsed["structure"],
+        )
 
     if source.startswith("discourse:"):
         from oikb.connectors.discourse import DiscourseConnector, parse_discourse_source

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -164,7 +164,8 @@ def _resolve_connector(source: str, branch: str | None = None, path: str | None 
         from oikb.connectors.bookstack import BookStackConnector, parse_bookstack_source
         parsed = parse_bookstack_source(source)
         return BookStackConnector(
-            ids=parsed["ids"],
+            include_ids=parsed["include_ids"],
+            exclude_ids=parsed["exclude_ids"],
             scope=parsed["scope"],
             export_output=parsed["output"],
             export_format=parsed["format"],

--- a/src/oikb/connectors/bookstack.py
+++ b/src/oikb/connectors/bookstack.py
@@ -31,7 +31,7 @@ FORMAT_EXT = {
 SCOPES = {"pages", "books", "shelves"}
 OUTPUTS = {"pages", "chapters", "books"}
 STRUCTURES = {"flat", "hierarchical"}
-PARAMS = {"scope", "output", "format", "structure"}
+PARAMS = {"include_ids", "exclude_ids", "output", "format", "structure"}
 
 
 class BookStackConnector(BaseConnector):
@@ -42,7 +42,8 @@ class BookStackConnector(BaseConnector):
         base_url: str | None = None,
         token_id: str | None = None,
         token_secret: str | None = None,
-        ids: list[str] | None = None,
+        include_ids: list[str] | None = None,
+        exclude_ids: list[str] | None = None,
         scope: str = "books",
         export_output: str = "pages",
         export_format: str = "md",
@@ -54,7 +55,8 @@ class BookStackConnector(BaseConnector):
         if not self._url or not tid or not ts:
             raise ValueError("BookStack credentials required. Set BOOKSTACK_URL, BOOKSTACK_TOKEN_ID, BOOKSTACK_TOKEN_SECRET.")
         self._http = httpx.Client(base_url=self._url, headers={"Authorization": f"Token {tid}:{ts}"}, timeout=30.0)
-        self.ids = ids or []
+        self.include_ids = include_ids or []
+        self.exclude_ids = set(exclude_ids or [])
         self.scope = scope
         self.export_output = export_output
         self.export_format = export_format
@@ -79,11 +81,13 @@ class BookStackConnector(BaseConnector):
 
     def _build_pages_scope_manifest(self) -> list[ManifestEntry]:
         entries: list[ManifestEntry] = []
-        if self.ids:
-            pages = [self._get_page(page_id) for page_id in self.ids]
+        if self.include_ids:
+            pages = [self._get_page(page_id) for page_id in self.include_ids]
         else:
             pages = self._list_paginated("/api/pages")
         for page in pages:
+            if self._is_excluded(page):
+                continue
             entries.append(self._page_entry(page))
         return entries
 
@@ -116,13 +120,15 @@ class BookStackConnector(BaseConnector):
 
     def _build_shelves_manifest(self) -> list[ManifestEntry]:
         entries: list[ManifestEntry] = []
-        if self.ids:
-            shelves = [self._get_shelf(shelf_id) for shelf_id in self.ids]
+        if self.include_ids:
+            shelves = [self._get_shelf(shelf_id) for shelf_id in self.include_ids]
         else:
             shelves = [self._get_shelf(str(shelf["id"])) for shelf in self._list_paginated("/api/shelves")]
         # A book can appear on multiple shelves; export it only once.
         seen_books: set[str] = set()
         for shelf in shelves:
+            if self._is_excluded(shelf):
+                continue
             shelf_name = shelf.get("name", "Untitled") if self.structure == "hierarchical" else None
             books = []
             for book in shelf.get("books", []):
@@ -140,9 +146,14 @@ class BookStackConnector(BaseConnector):
         return entries
 
     def _selected_books(self) -> list[dict]:
-        if self.ids:
-            return [self._get_book(book_id) for book_id in self.ids]
-        return self._list_paginated("/api/books")
+        if self.include_ids:
+            books = [self._get_book(book_id) for book_id in self.include_ids]
+        else:
+            books = self._list_paginated("/api/books")
+        return [book for book in books if not self._is_excluded(book)]
+
+    def _is_excluded(self, item: dict) -> bool:
+        return str(item["id"]) in self.exclude_ids
 
     def _page_entry(self, page: dict, shelf_name: str | None = None) -> ManifestEntry:
         page_id = str(page["id"])
@@ -284,10 +295,11 @@ class BookStackConnector(BaseConnector):
 
 def parse_bookstack_source(source: str) -> dict:
     raw = source.removeprefix("bookstack:")
-    id_part, sep, query = raw.partition("?")
+    scope_part, sep, query = raw.partition("?")
     result = {
-        "ids": _parse_ids(id_part),
-        "scope": "books",
+        "include_ids": [],
+        "exclude_ids": [],
+        "scope": scope_part or "books",
         "output": "pages",
         "format": "md",
         "structure": "flat",
@@ -300,10 +312,15 @@ def parse_bookstack_source(source: str) -> dict:
         seen.add(key)
         if key not in PARAMS:
             raise ValueError(f"Invalid BookStack source. Unknown parameter: {key}")
-        result[key] = value
+        if key in {"include_ids", "exclude_ids"}:
+            result[key] = _parse_ids(value)
+        else:
+            result[key] = value
 
     if result["scope"] not in SCOPES:
-        raise ValueError("Invalid BookStack source. Expected scope=pages, scope=books, or scope=shelves")
+        raise ValueError("Invalid BookStack source. Expected bookstack:, bookstack:pages, bookstack:books, or bookstack:shelves")
+    if result["include_ids"] and result["exclude_ids"]:
+        raise ValueError("Invalid BookStack source. include_ids and exclude_ids cannot be used together")
     if result["output"] not in OUTPUTS:
         raise ValueError("Invalid BookStack source. Expected output=pages, output=chapters, or output=books")
     if result["format"] not in FORMAT_EXPORT:
@@ -319,8 +336,8 @@ def parse_bookstack_source(source: str) -> dict:
 
 def _parse_ids(raw: str) -> list[str]:
     if not raw:
-        return []
+        raise ValueError("Invalid BookStack source. Expected positive numeric IDs, e.g. include_ids=12,34")
     parts = raw.split(",")
     if any(not part or not part.isdecimal() or int(part) <= 0 for part in parts):
-        raise ValueError("Invalid BookStack source. Expected positive numeric IDs, e.g. bookstack:12,34")
+        raise ValueError("Invalid BookStack source. Expected positive numeric IDs, e.g. include_ids=12,34")
     return list(dict.fromkeys(parts))

--- a/src/oikb/connectors/bookstack.py
+++ b/src/oikb/connectors/bookstack.py
@@ -1,4 +1,4 @@
-"""BookStack connector — sync pages from a BookStack instance.
+"""BookStack connector — sync BookStack content.
 
 Auth via BOOKSTACK_URL, BOOKSTACK_TOKEN_ID, BOOKSTACK_TOKEN_SECRET env vars.
 """
@@ -8,53 +8,278 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+from urllib.parse import parse_qsl
 
 import httpx
 
 from oikb.connectors import BaseConnector, ManifestEntry
 
+FORMAT_EXPORT = {
+    "txt": "plaintext",
+    "md": "markdown",
+    "html": "html",
+    "pdf": "pdf",
+}
+
+FORMAT_EXT = {
+    "txt": ".txt",
+    "md": ".md",
+    "html": ".html",
+    "pdf": ".pdf",
+}
+
+SCOPES = {"pages", "books", "shelves"}
+OUTPUTS = {"pages", "books"}
+STRUCTURES = {"flat", "hierarchical"}
+PARAMS = {"scope", "output", "format", "structure"}
+
 
 class BookStackConnector(BaseConnector):
-    """Sync pages from BookStack."""
+    """Sync pages or books from BookStack using native export endpoints."""
 
-    def __init__(self, base_url: str | None = None, token_id: str | None = None, token_secret: str | None = None):
+    def __init__(
+        self,
+        base_url: str | None = None,
+        token_id: str | None = None,
+        token_secret: str | None = None,
+        ids: list[str] | None = None,
+        scope: str = "books",
+        export_output: str = "pages",
+        export_format: str = "md",
+        structure: str = "flat",
+    ):
         self._url = (base_url or os.environ.get("BOOKSTACK_URL", "")).rstrip("/")
         tid = token_id or os.environ.get("BOOKSTACK_TOKEN_ID", "")
         ts = token_secret or os.environ.get("BOOKSTACK_TOKEN_SECRET", "")
         if not self._url or not tid or not ts:
             raise ValueError("BookStack credentials required. Set BOOKSTACK_URL, BOOKSTACK_TOKEN_ID, BOOKSTACK_TOKEN_SECRET.")
         self._http = httpx.Client(base_url=self._url, headers={"Authorization": f"Token {tid}:{ts}"}, timeout=30.0)
-        self._cache: dict[str, str] = {}
+        self.ids = ids or []
+        self.scope = scope
+        self.export_output = export_output
+        self.export_format = export_format
+        self.structure = structure
+        self._cache: dict[str, tuple[str, str]] = {}
+        self._books: dict[str, dict] = {}
+        self._chapters: dict[str, dict] = {}
 
     def build_manifest(self) -> list[ManifestEntry]:
-        entries: list[ManifestEntry] = []
-        offset = 0
-        while True:
-            resp = self._http.get("/api/pages", params={"count": 100, "offset": offset})
-            resp.raise_for_status()
-            data = resp.json()
-            for page in data.get("data", []):
-                title = re.sub(r'[<>:"/\\|?*]', "_", page.get("name", "Untitled"))
-                filename = f"{page['id']}_{title[:50]}.txt"
-                checksum = hashlib.sha256(f"{page['id']}:{page.get('updated_at', '')}".encode()).hexdigest()[:16]
-                entries.append(ManifestEntry(filename=filename, path="", checksum=checksum, size=0))
-            if len(data.get("data", [])) < 100:
-                break
-            offset += 100
+        if self.scope == "pages":
+            entries = self._build_pages_scope_manifest()
+        elif self.scope == "books" and self.export_output == "books":
+            entries = self._build_books_manifest(self._selected_books())
+        elif self.scope == "books":
+            entries = self._build_pages_from_books(self._selected_books())
+        else:
+            entries = self._build_shelves_manifest()
         entries.sort(key=lambda e: e.display_path)
         return entries
 
-    def read_file(self, path: str, filename: str) -> bytes:
-        page_id = filename.split("_")[0]
+    def _build_pages_scope_manifest(self) -> list[ManifestEntry]:
+        entries: list[ManifestEntry] = []
+        if self.ids:
+            pages = [self._get_page(page_id) for page_id in self.ids]
+        else:
+            pages = self._list_paginated("/api/pages")
+        for page in pages:
+            entries.append(self._page_entry(page))
+        return entries
+
+    def _build_pages_from_books(self, books: list[dict], shelf_name: str | None = None) -> list[ManifestEntry]:
+        entries: list[ManifestEntry] = []
+        for book in books:
+            book_id = str(book["id"])
+            self._books[book_id] = book
+            pages = self._list_paginated("/api/pages", {"filter[book_id]": book_id})
+            for page in pages:
+                entries.append(self._page_entry(page, shelf_name=shelf_name))
+        return entries
+
+    def _build_books_manifest(self, books: list[dict], shelf_name: str | None = None) -> list[ManifestEntry]:
+        entries: list[ManifestEntry] = []
+        for book in books:
+            entries.append(self._book_entry(self._get_book(str(book["id"])), shelf_name=shelf_name))
+        return entries
+
+    def _build_shelves_manifest(self) -> list[ManifestEntry]:
+        entries: list[ManifestEntry] = []
+        if self.ids:
+            shelves = [self._get_shelf(shelf_id) for shelf_id in self.ids]
+        else:
+            shelves = [self._get_shelf(str(shelf["id"])) for shelf in self._list_paginated("/api/shelves")]
+        # A book can appear on multiple shelves; export it only once.
+        seen_books: set[str] = set()
+        for shelf in shelves:
+            shelf_name = shelf.get("name", "Untitled") if self.structure == "hierarchical" else None
+            books = []
+            for book in shelf.get("books", []):
+                book_id = str(book["id"])
+                if book_id in seen_books:
+                    continue
+                seen_books.add(book_id)
+                books.append(book)
+            if self.export_output == "books":
+                entries.extend(self._build_books_manifest(books, shelf_name=shelf_name))
+            else:
+                entries.extend(self._build_pages_from_books(books, shelf_name=shelf_name))
+        return entries
+
+    def _selected_books(self) -> list[dict]:
+        if self.ids:
+            return [self._get_book(book_id) for book_id in self.ids]
+        return self._list_paginated("/api/books")
+
+    def _page_entry(self, page: dict, shelf_name: str | None = None) -> ManifestEntry:
+        page_id = str(page["id"])
+        title = self._safe_name(page.get("name", "Untitled"))
+        filename = f"{page_id}_{title[:80]}{FORMAT_EXT[self.export_format]}"
+        path = self._page_path(page, shelf_name=shelf_name)
+        checksum = self._checksum("page", page_id, str(page.get("updated_at") or ""))
+        self._cache[self._entry_key(path, filename)] = ("pages", page_id)
+        return ManifestEntry(filename=filename, path=path, checksum=checksum, size=0)
+
+    def _book_entry(self, book: dict, shelf_name: str | None = None) -> ManifestEntry:
+        book_id = str(book["id"])
+        title = self._safe_name(book.get("name", "Untitled"))
+        filename = f"{book_id}_{title[:80]}{FORMAT_EXT[self.export_format]}"
+        path = self._safe_name(shelf_name) if shelf_name and self.structure == "hierarchical" else ""
+        checksum = self._book_checksum(book)
+        self._cache[self._entry_key(path, filename)] = ("books", book_id)
+        return ManifestEntry(filename=filename, path=path, checksum=checksum, size=0)
+
+    def _page_path(self, page: dict, shelf_name: str | None = None) -> str:
+        if self.structure != "hierarchical":
+            return ""
+        parts: list[str] = []
+        if shelf_name:
+            parts.append(shelf_name)
+        book_id = page.get("book_id")
+        if book_id:
+            parts.append(self._get_book(str(book_id)).get("name", "Untitled"))
+        chapter_id = page.get("chapter_id")
+        if chapter_id:
+            parts.append(self._get_chapter(str(chapter_id)).get("name", "Untitled"))
+        return "/".join(self._safe_name(part) for part in parts if part)
+
+    def _get_page(self, page_id: str) -> dict:
         resp = self._http.get(f"/api/pages/{page_id}")
         resp.raise_for_status()
-        data = resp.json()
-        text = f"# {data.get('name', '')}\n\n{re.sub(r'<[^>]+>', ' ', data.get('html', ''))}"
-        return text.encode("utf-8")
+        return resp.json()
+
+    def _get_book(self, book_id: str) -> dict:
+        if book_id not in self._books:
+            resp = self._http.get(f"/api/books/{book_id}")
+            resp.raise_for_status()
+            self._books[book_id] = resp.json()
+        return self._books[book_id]
+
+    def _get_chapter(self, chapter_id: str) -> dict:
+        if chapter_id not in self._chapters:
+            resp = self._http.get(f"/api/chapters/{chapter_id}")
+            resp.raise_for_status()
+            self._chapters[chapter_id] = resp.json()
+        return self._chapters[chapter_id]
+
+    def _get_shelf(self, shelf_id: str) -> dict:
+        resp = self._http.get(f"/api/shelves/{shelf_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def _list_paginated(self, endpoint: str, params: dict[str, str] | None = None) -> list[dict]:
+        items: list[dict] = []
+        offset = 0
+        while True:
+            page_params: dict[str, str | int] = {"count": 100, "offset": offset}
+            if params:
+                page_params.update(params)
+            resp = self._http.get(endpoint, params=page_params)
+            resp.raise_for_status()
+            data = resp.json().get("data", [])
+            items.extend(data)
+            if len(data) < 100:
+                break
+            offset += 100
+        return items
+
+    def read_file(self, path: str, filename: str) -> bytes:
+        key = self._entry_key(path, filename)
+        # Filenames are not parsed because titles can change; manifest building records the export target.
+        cached = self._cache.get(key)
+        if not cached:
+            raise FileNotFoundError(f"BookStack entry not found: {key}")
+        api_resource, item_id = cached
+        resp = self._http.get(f"/api/{api_resource}/{item_id}/export/{FORMAT_EXPORT[self.export_format]}")
+        resp.raise_for_status()
+        return resp.content
 
     def close(self) -> None:
         self._http.close()
 
+    def _checksum(self, entity: str, item_id: str, updated_at: str) -> str:
+        value = f"{entity}:{item_id}:{updated_at}:{self.scope}:{self.export_output}:{self.export_format}:{self.structure}"
+        return hashlib.sha256(value.encode()).hexdigest()[:16]
 
-def parse_bookstack_source(source: str) -> dict[str, str | None]:
-    return {}
+    def _book_checksum(self, book: dict) -> str:
+        book_id = str(book["id"])
+        # Book exports include nested chapter/page content, so page updates must invalidate the book file.
+        updates = [str(book.get("updated_at") or "")]
+        for item in book.get("contents", []) or []:
+            if item.get("updated_at"):
+                updates.append(str(item["updated_at"]))
+            for page in item.get("pages", []) or []:
+                if page.get("updated_at"):
+                    updates.append(str(page["updated_at"]))
+        return self._checksum("book", book_id, ":".join(updates))
+
+    @staticmethod
+    def _safe_name(name: str | None) -> str:
+        safe = re.sub(r'[<>:"/\\|?*]', "_", name or "Untitled").strip()
+        return safe or "Untitled"
+
+    @staticmethod
+    def _entry_key(path: str, filename: str) -> str:
+        return f"{path}/{filename}" if path else filename
+
+
+def parse_bookstack_source(source: str) -> dict:
+    raw = source.removeprefix("bookstack:")
+    id_part, sep, query = raw.partition("?")
+    result = {
+        "ids": _parse_ids(id_part),
+        "scope": "books",
+        "output": "pages",
+        "format": "md",
+        "structure": "flat",
+    }
+
+    seen: set[str] = set()
+    for key, value in parse_qsl(query, keep_blank_values=True) if sep else []:
+        if key in seen:
+            raise ValueError(f"Invalid BookStack source. Duplicate parameter: {key}")
+        seen.add(key)
+        if key not in PARAMS:
+            raise ValueError(f"Invalid BookStack source. Unknown parameter: {key}")
+        result[key] = value
+
+    if result["scope"] not in SCOPES:
+        raise ValueError("Invalid BookStack source. Expected scope=pages, scope=books, or scope=shelves")
+    if result["output"] not in OUTPUTS:
+        raise ValueError("Invalid BookStack source. Expected output=pages or output=books")
+    if result["format"] not in FORMAT_EXPORT:
+        raise ValueError("Invalid BookStack source. Expected format=txt, format=md, format=html, or format=pdf")
+    if result["structure"] not in STRUCTURES:
+        raise ValueError("Invalid BookStack source. Expected structure=flat or structure=hierarchical")
+
+    if result["scope"] == "pages" and result["output"] == "books":
+        result["output"] = "pages"
+
+    return result
+
+
+def _parse_ids(raw: str) -> list[str]:
+    if not raw:
+        return []
+    parts = raw.split(",")
+    if any(not part or not part.isdecimal() or int(part) <= 0 for part in parts):
+        raise ValueError("Invalid BookStack source. Expected positive numeric IDs, e.g. bookstack:12,34")
+    return list(dict.fromkeys(parts))

--- a/src/oikb/connectors/bookstack.py
+++ b/src/oikb/connectors/bookstack.py
@@ -29,7 +29,7 @@ FORMAT_EXT = {
 }
 
 SCOPES = {"pages", "books", "shelves"}
-OUTPUTS = {"pages", "books"}
+OUTPUTS = {"pages", "chapters", "books"}
 STRUCTURES = {"flat", "hierarchical"}
 PARAMS = {"scope", "output", "format", "structure"}
 
@@ -68,6 +68,8 @@ class BookStackConnector(BaseConnector):
             entries = self._build_pages_scope_manifest()
         elif self.scope == "books" and self.export_output == "books":
             entries = self._build_books_manifest(self._selected_books())
+        elif self.scope == "books" and self.export_output == "chapters":
+            entries = self._build_chapters_manifest(self._selected_books())
         elif self.scope == "books":
             entries = self._build_pages_from_books(self._selected_books())
         else:
@@ -101,6 +103,17 @@ class BookStackConnector(BaseConnector):
             entries.append(self._book_entry(self._get_book(str(book["id"])), shelf_name=shelf_name))
         return entries
 
+    def _build_chapters_manifest(self, books: list[dict], shelf_name: str | None = None) -> list[ManifestEntry]:
+        entries: list[ManifestEntry] = []
+        for book in books:
+            full_book = self._get_book(str(book["id"]))
+            for item in full_book.get("contents", []) or []:
+                if item.get("type") == "chapter" and item.get("pages"):
+                    entries.append(self._chapter_entry(item, full_book, shelf_name=shelf_name))
+                elif item.get("type") == "page":
+                    entries.append(self._page_entry(item, shelf_name=shelf_name))
+        return entries
+
     def _build_shelves_manifest(self) -> list[ManifestEntry]:
         entries: list[ManifestEntry] = []
         if self.ids:
@@ -120,6 +133,8 @@ class BookStackConnector(BaseConnector):
                 books.append(book)
             if self.export_output == "books":
                 entries.extend(self._build_books_manifest(books, shelf_name=shelf_name))
+            elif self.export_output == "chapters":
+                entries.extend(self._build_chapters_manifest(books, shelf_name=shelf_name))
             else:
                 entries.extend(self._build_pages_from_books(books, shelf_name=shelf_name))
         return entries
@@ -147,6 +162,15 @@ class BookStackConnector(BaseConnector):
         self._cache[self._entry_key(path, filename)] = ("books", book_id)
         return ManifestEntry(filename=filename, path=path, checksum=checksum, size=0)
 
+    def _chapter_entry(self, chapter: dict, book: dict, shelf_name: str | None = None) -> ManifestEntry:
+        chapter_id = str(chapter["id"])
+        title = self._safe_name(chapter.get("name", "Untitled"))
+        filename = f"{chapter_id}_{title[:80]}{FORMAT_EXT[self.export_format]}"
+        path = self._chapter_path(book, shelf_name=shelf_name)
+        checksum = self._chapter_checksum(chapter)
+        self._cache[self._entry_key(path, filename)] = ("chapters", chapter_id)
+        return ManifestEntry(filename=filename, path=path, checksum=checksum, size=0)
+
     def _page_path(self, page: dict, shelf_name: str | None = None) -> str:
         if self.structure != "hierarchical":
             return ""
@@ -159,6 +183,15 @@ class BookStackConnector(BaseConnector):
         chapter_id = page.get("chapter_id")
         if chapter_id:
             parts.append(self._get_chapter(str(chapter_id)).get("name", "Untitled"))
+        return "/".join(self._safe_name(part) for part in parts if part)
+
+    def _chapter_path(self, book: dict, shelf_name: str | None = None) -> str:
+        if self.structure != "hierarchical":
+            return ""
+        parts = []
+        if shelf_name:
+            parts.append(shelf_name)
+        parts.append(book.get("name", "Untitled"))
         return "/".join(self._safe_name(part) for part in parts if part)
 
     def _get_page(self, page_id: str) -> dict:
@@ -231,6 +264,14 @@ class BookStackConnector(BaseConnector):
                     updates.append(str(page["updated_at"]))
         return self._checksum("book", book_id, ":".join(updates))
 
+    def _chapter_checksum(self, chapter: dict) -> str:
+        chapter_id = str(chapter["id"])
+        updates = [str(chapter.get("updated_at") or "")]
+        for page in chapter.get("pages", []) or []:
+            if page.get("updated_at"):
+                updates.append(str(page["updated_at"]))
+        return self._checksum("chapter", chapter_id, ":".join(updates))
+
     @staticmethod
     def _safe_name(name: str | None) -> str:
         safe = re.sub(r'[<>:"/\\|?*]', "_", name or "Untitled").strip()
@@ -264,13 +305,13 @@ def parse_bookstack_source(source: str) -> dict:
     if result["scope"] not in SCOPES:
         raise ValueError("Invalid BookStack source. Expected scope=pages, scope=books, or scope=shelves")
     if result["output"] not in OUTPUTS:
-        raise ValueError("Invalid BookStack source. Expected output=pages or output=books")
+        raise ValueError("Invalid BookStack source. Expected output=pages, output=chapters, or output=books")
     if result["format"] not in FORMAT_EXPORT:
         raise ValueError("Invalid BookStack source. Expected format=txt, format=md, format=html, or format=pdf")
     if result["structure"] not in STRUCTURES:
         raise ValueError("Invalid BookStack source. Expected structure=flat or structure=hierarchical")
 
-    if result["scope"] == "pages" and result["output"] == "books":
+    if result["scope"] == "pages" and result["output"] in {"books", "chapters"}:
         result["output"] = "pages"
 
     return result

--- a/tests/test_bookstack.py
+++ b/tests/test_bookstack.py
@@ -1,0 +1,347 @@
+import pytest
+from httpx import Request, Response
+
+from oikb.connectors.bookstack import BookStackConnector, parse_bookstack_source
+
+
+def test_parse_bookstack_defaults():
+    assert parse_bookstack_source("bookstack:") == {
+        "ids": [],
+        "scope": "books",
+        "output": "pages",
+        "format": "md",
+        "structure": "flat",
+    }
+
+
+def test_parse_bookstack_ids_and_options():
+    assert parse_bookstack_source("bookstack:12,34?scope=shelves&output=books&format=pdf&structure=hierarchical") == {
+        "ids": ["12", "34"],
+        "scope": "shelves",
+        "output": "books",
+        "format": "pdf",
+        "structure": "hierarchical",
+    }
+
+
+def test_parse_bookstack_deduplicates_ids():
+    assert parse_bookstack_source("bookstack:12,12,34")["ids"] == ["12", "34"]
+
+
+def test_parse_bookstack_pages_books_fallback():
+    parsed = parse_bookstack_source("bookstack:12?scope=pages&output=books")
+    assert parsed["output"] == "pages"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "bookstack:abc",
+        "bookstack:12,,34",
+        "bookstack:?scope=book",
+        "bookstack:?output=chapters",
+        "bookstack:?format=markdown",
+        "bookstack:?format=zip",
+        "bookstack:?structure=nested",
+        "bookstack:?unknown=value",
+        "bookstack:?format=md&format=txt",
+    ],
+)
+def test_parse_bookstack_rejects_invalid_sources(source):
+    with pytest.raises(ValueError):
+        parse_bookstack_source(source)
+
+
+def test_default_manifest_lists_books_then_pages_as_markdown():
+    http = FakeHTTP({
+        "/api/books": Response(200, json={"data": [{"id": 12, "name": "Guide", "updated_at": "2026-01-01"}]}),
+        "/api/pages": Response(200, json={"data": [{"id": 99, "book_id": 12, "name": "Install", "updated_at": "2026-01-02"}]}),
+        "/api/pages/99/export/markdown": Response(200, content=b"# Install"),
+    })
+
+    connector = _connector()
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+        content = connector.read_file(manifest[0].path, manifest[0].filename)
+    finally:
+        connector.close()
+
+    assert http.calls[0][0] == "/api/books"
+    assert http.calls[1][1]["filter[book_id]"] == "12"
+    assert manifest[0].filename == "99_Install.md"
+    assert manifest[0].path == ""
+    assert content == b"# Install"
+    assert http.calls[2][0] == "/api/pages/99/export/markdown"
+
+
+def test_pages_scope_with_ids_reads_pages_directly_as_plaintext():
+    http = FakeHTTP({
+        "/api/pages/99": Response(200, json={"id": 99, "name": "Install", "updated_at": "2026-01-02"}),
+        "/api/pages/99/export/plaintext": Response(200, content=b"Install"),
+    })
+
+    connector = _connector(ids=["99"], scope="pages", export_format="txt")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+        content = connector.read_file(manifest[0].path, manifest[0].filename)
+    finally:
+        connector.close()
+
+    assert manifest[0].filename == "99_Install.txt"
+    assert content == b"Install"
+    assert http.calls[1][0] == "/api/pages/99/export/plaintext"
+
+
+def test_books_scope_outputs_books_as_pdf():
+    http = FakeHTTP({
+        "/api/books/12": Response(200, json={"id": 12, "name": "Guide", "updated_at": "2026-01-01"}),
+        "/api/books/12/export/pdf": Response(200, content=b"%PDF"),
+    })
+
+    connector = _connector(ids=["12"], export_output="books", export_format="pdf", structure="hierarchical")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+        content = connector.read_file(manifest[0].path, manifest[0].filename)
+    finally:
+        connector.close()
+
+    assert manifest[0].filename == "12_Guide.pdf"
+    assert manifest[0].path == ""
+    assert content == b"%PDF"
+    assert http.calls[1][0] == "/api/books/12/export/pdf"
+
+
+def test_hierarchical_pages_use_book_and_chapter_paths():
+    http = FakeHTTP({
+        "/api/books/12": Response(200, json={"id": 12, "name": "User Guide", "updated_at": "2026-01-01"}),
+        "/api/pages": Response(200, json={"data": [{"id": 99, "book_id": 12, "chapter_id": 7, "name": "Install", "updated_at": "2026-01-02"}]}),
+        "/api/chapters/7": Response(200, json={"id": 7, "name": "Setup"}),
+    })
+
+    connector = _connector(ids=["12"], structure="hierarchical")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert manifest[0].path == "User Guide/Setup"
+
+
+def test_shelves_dedupe_books_and_use_shelf_path_for_book_output():
+    http = FakeHTTP({
+        "/api/shelves/5": Response(
+            200,
+            json={
+                "id": 5,
+                "name": "Knowledge",
+                "books": [
+                    {"id": 12, "name": "Guide", "updated_at": "2026-01-01"},
+                    {"id": 12, "name": "Guide", "updated_at": "2026-01-01"},
+                ],
+            },
+        ),
+        "/api/books/12": Response(200, json={"id": 12, "name": "Guide", "updated_at": "2026-01-01"}),
+    })
+
+    connector = _connector(ids=["5"], scope="shelves", export_output="books", structure="hierarchical")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert len(manifest) == 1
+    assert manifest[0].filename == "12_Guide.md"
+    assert manifest[0].path == "Knowledge"
+
+
+def test_book_output_checksum_includes_nested_page_updates():
+    old_book = {
+        "id": 12,
+        "name": "Guide",
+        "updated_at": "2026-01-01",
+        "contents": [
+            {
+                "id": 7,
+                "type": "chapter",
+                "updated_at": "2026-01-01",
+                "pages": [{"id": 99, "updated_at": "2026-01-02"}],
+            }
+        ],
+    }
+    new_book = {
+        **old_book,
+        "contents": [
+            {
+                "id": 7,
+                "type": "chapter",
+                "updated_at": "2026-01-01",
+                "pages": [{"id": 99, "updated_at": "2026-02-01"}],
+            }
+        ],
+    }
+
+    old_http = FakeHTTP({"/api/books/12": Response(200, json=old_book)})
+    new_http = FakeHTTP({"/api/books/12": Response(200, json=new_book)})
+
+    old_connector = _connector(ids=["12"], export_output="books")
+    new_connector = _connector(ids=["12"], export_output="books")
+    old_connector._http = old_http
+    new_connector._http = new_http
+    try:
+        old_checksum = old_connector.build_manifest()[0].checksum
+        new_checksum = new_connector.build_manifest()[0].checksum
+    finally:
+        old_connector.close()
+        new_connector.close()
+
+    assert old_checksum != new_checksum
+
+
+def test_shelf_without_books_returns_empty_manifest():
+    http = FakeHTTP({
+        "/api/shelves/5": Response(200, json={"id": 5, "name": "Empty", "books": []}),
+    })
+
+    connector = _connector(ids=["5"], scope="shelves", export_output="books")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert manifest == []
+
+
+def test_shelves_scope_without_ids_lists_shelves():
+    http = FakeHTTP({
+        "/api/shelves": Response(200, json={"data": [{"id": 5, "name": "Knowledge"}]}),
+        "/api/shelves/5": Response(200, json={"id": 5, "name": "Knowledge", "books": []}),
+    })
+
+    connector = _connector(scope="shelves")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert manifest == []
+    assert http.calls[0] == ("/api/shelves", {"count": 100, "offset": 0})
+    assert http.calls[1] == ("/api/shelves/5", {})
+
+
+def test_shelves_scope_outputs_hierarchical_pages():
+    http = FakeHTTP({
+        "/api/shelves/5": Response(
+            200,
+            json={
+                "id": 5,
+                "name": "Knowledge",
+                "books": [{"id": 12, "name": "Guide", "updated_at": "2026-01-01"}],
+            },
+        ),
+        "/api/pages": Response(200, json={"data": [{"id": 99, "book_id": 12, "chapter_id": 7, "name": "Install", "updated_at": "2026-01-02"}]}),
+        "/api/chapters/7": Response(200, json={"id": 7, "name": "Setup"}),
+    })
+
+    connector = _connector(ids=["5"], scope="shelves", structure="hierarchical")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert manifest[0].filename == "99_Install.md"
+    assert manifest[0].path == "Knowledge/Guide/Setup"
+    assert http.calls[1] == ("/api/pages", {"count": 100, "offset": 0, "filter[book_id]": "12"})
+
+
+def test_paginated_book_listing_reads_second_page():
+    first_page = [{"id": i, "name": f"Book {i}", "updated_at": "2026-01-01"} for i in range(1, 101)]
+    second_page = [{"id": 101, "name": "Book 101", "updated_at": "2026-01-01"}]
+    http = FakeHTTP({
+        "/api/books": [
+            Response(200, json={"data": first_page}),
+            Response(200, json={"data": second_page}),
+        ],
+    })
+
+    connector = _connector(export_output="books")
+    connector._http = http
+    try:
+        books = connector._list_paginated("/api/books")
+    finally:
+        connector.close()
+
+    assert len(books) == 101
+    assert http.calls[0] == ("/api/books", {"count": 100, "offset": 0})
+    assert http.calls[1] == ("/api/books", {"count": 100, "offset": 100})
+
+
+@pytest.mark.parametrize(
+    ("fmt", "extension", "export_name"),
+    [
+        ("txt", ".txt", "plaintext"),
+        ("md", ".md", "markdown"),
+        ("html", ".html", "html"),
+        ("pdf", ".pdf", "pdf"),
+    ],
+)
+def test_format_mapping_for_book_exports(fmt, extension, export_name):
+    http = FakeHTTP({
+        "/api/books/12": Response(200, json={"id": 12, "name": "Guide", "updated_at": "2026-01-01"}),
+        f"/api/books/12/export/{export_name}": Response(200, content=b"content"),
+    })
+
+    connector = _connector(ids=["12"], export_output="books", export_format=fmt)
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+        content = connector.read_file(manifest[0].path, manifest[0].filename)
+    finally:
+        connector.close()
+
+    assert manifest[0].filename.endswith(extension)
+    assert content == b"content"
+    assert http.calls[1][0] == f"/api/books/12/export/{export_name}"
+
+
+def test_read_file_requires_manifest_cache():
+    connector = _connector()
+    try:
+        with pytest.raises(FileNotFoundError):
+            connector.read_file("", "missing.md")
+    finally:
+        connector.close()
+
+
+class FakeHTTP:
+    def __init__(self, routes):
+        self.routes = routes
+        self.calls = []
+
+    def get(self, path, params=None):
+        self.calls.append((path, params or {}))
+        response = self.routes[path]
+        if isinstance(response, list):
+            response = response.pop(0)
+        if response._request is None:
+            response._request = Request("GET", f"https://bookstack.example{path}")
+        return response
+
+    def close(self):
+        pass
+
+
+def _connector(**kwargs):
+    return BookStackConnector(
+        base_url="https://bookstack.example",
+        token_id="id",
+        token_secret="secret",
+        **kwargs,
+    )

--- a/tests/test_bookstack.py
+++ b/tests/test_bookstack.py
@@ -33,13 +33,23 @@ def test_parse_bookstack_pages_books_fallback():
     assert parsed["output"] == "pages"
 
 
+def test_parse_bookstack_accepts_chapter_output():
+    parsed = parse_bookstack_source("bookstack:12?scope=books&output=chapters")
+    assert parsed["output"] == "chapters"
+
+
+def test_parse_bookstack_pages_chapters_fallback():
+    parsed = parse_bookstack_source("bookstack:12?scope=pages&output=chapters")
+    assert parsed["output"] == "pages"
+
+
 @pytest.mark.parametrize(
     "source",
     [
         "bookstack:abc",
         "bookstack:12,,34",
         "bookstack:?scope=book",
-        "bookstack:?output=chapters",
+        "bookstack:?output=chapter",
         "bookstack:?format=markdown",
         "bookstack:?format=zip",
         "bookstack:?structure=nested",
@@ -190,6 +200,138 @@ def test_book_output_checksum_includes_nested_page_updates():
 
     old_connector = _connector(ids=["12"], export_output="books")
     new_connector = _connector(ids=["12"], export_output="books")
+    old_connector._http = old_http
+    new_connector._http = new_http
+    try:
+        old_checksum = old_connector.build_manifest()[0].checksum
+        new_checksum = new_connector.build_manifest()[0].checksum
+    finally:
+        old_connector.close()
+        new_connector.close()
+
+    assert old_checksum != new_checksum
+
+
+def test_chapter_output_uses_book_contents_and_keeps_standalone_pages():
+    http = FakeHTTP({
+        "/api/books/12": Response(
+            200,
+            json={
+                "id": 12,
+                "name": "Guide",
+                "updated_at": "2026-01-01",
+                "contents": [
+                    {
+                        "id": 7,
+                        "type": "chapter",
+                        "name": "Setup",
+                        "updated_at": "2026-01-02",
+                        "pages": [
+                            {"id": 99, "updated_at": "2026-01-03"},
+                            {"id": 100, "updated_at": "2026-01-04"},
+                        ],
+                    },
+                    {"id": 8, "type": "chapter", "name": "Empty", "pages": []},
+                    {
+                        "id": 101,
+                        "type": "page",
+                        "book_id": 12,
+                        "chapter_id": None,
+                        "name": "Standalone",
+                        "updated_at": "2026-01-05",
+                    },
+                ],
+            },
+        ),
+        "/api/chapters/7/export/markdown": Response(200, content=b"# Setup"),
+        "/api/pages/101/export/markdown": Response(200, content=b"# Standalone"),
+    })
+
+    connector = _connector(ids=["12"], export_output="chapters")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+        contents = {entry.filename: connector.read_file(entry.path, entry.filename) for entry in manifest}
+    finally:
+        connector.close()
+
+    assert [entry.filename for entry in manifest] == ["101_Standalone.md", "7_Setup.md"]
+    assert contents == {"7_Setup.md": b"# Setup", "101_Standalone.md": b"# Standalone"}
+    assert ("/api/chapters/7/export/markdown", {}) in http.calls
+    assert ("/api/pages/101/export/markdown", {}) in http.calls
+
+
+def test_shelf_chapter_output_uses_shelf_and_book_path():
+    http = FakeHTTP({
+        "/api/shelves/5": Response(
+            200,
+            json={"id": 5, "name": "Knowledge", "books": [{"id": 12, "name": "Guide"}]},
+        ),
+        "/api/books/12": Response(
+            200,
+            json={
+                "id": 12,
+                "name": "Guide",
+                "contents": [
+                    {"id": 7, "type": "chapter", "name": "Setup", "updated_at": "2026-01-02", "pages": [{"id": 99}]},
+                    {
+                        "id": 101,
+                        "type": "page",
+                        "book_id": 12,
+                        "chapter_id": None,
+                        "name": "Standalone",
+                        "updated_at": "2026-01-05",
+                    },
+                ],
+            },
+        ),
+    })
+
+    connector = _connector(ids=["5"], scope="shelves", export_output="chapters", structure="hierarchical")
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert [(entry.path, entry.filename) for entry in manifest] == [
+        ("Knowledge/Guide", "101_Standalone.md"),
+        ("Knowledge/Guide", "7_Setup.md"),
+    ]
+
+
+def test_chapter_output_checksum_includes_nested_page_updates():
+    old_book = {
+        "id": 12,
+        "name": "Guide",
+        "contents": [
+            {
+                "id": 7,
+                "type": "chapter",
+                "name": "Setup",
+                "updated_at": "2026-01-01",
+                "pages": [{"id": 99, "updated_at": "2026-01-02"}],
+            }
+        ],
+    }
+    new_book = {
+        **old_book,
+        "contents": [
+            {
+                "id": 7,
+                "type": "chapter",
+                "name": "Setup",
+                "updated_at": "2026-01-01",
+                "pages": [{"id": 99, "updated_at": "2026-02-01"}],
+            }
+        ],
+    }
+
+    old_http = FakeHTTP({"/api/books/12": Response(200, json=old_book)})
+    new_http = FakeHTTP({"/api/books/12": Response(200, json=new_book)})
+
+    old_connector = _connector(ids=["12"], export_output="chapters")
+    new_connector = _connector(ids=["12"], export_output="chapters")
     old_connector._http = old_http
     new_connector._http = new_http
     try:

--- a/tests/test_bookstack.py
+++ b/tests/test_bookstack.py
@@ -6,7 +6,8 @@ from oikb.connectors.bookstack import BookStackConnector, parse_bookstack_source
 
 def test_parse_bookstack_defaults():
     assert parse_bookstack_source("bookstack:") == {
-        "ids": [],
+        "include_ids": [],
+        "exclude_ids": [],
         "scope": "books",
         "output": "pages",
         "format": "md",
@@ -15,8 +16,9 @@ def test_parse_bookstack_defaults():
 
 
 def test_parse_bookstack_ids_and_options():
-    assert parse_bookstack_source("bookstack:12,34?scope=shelves&output=books&format=pdf&structure=hierarchical") == {
-        "ids": ["12", "34"],
+    assert parse_bookstack_source("bookstack:shelves?include_ids=12,34&output=books&format=pdf&structure=hierarchical") == {
+        "include_ids": ["12", "34"],
+        "exclude_ids": [],
         "scope": "shelves",
         "output": "books",
         "format": "pdf",
@@ -25,21 +27,27 @@ def test_parse_bookstack_ids_and_options():
 
 
 def test_parse_bookstack_deduplicates_ids():
-    assert parse_bookstack_source("bookstack:12,12,34")["ids"] == ["12", "34"]
+    assert parse_bookstack_source("bookstack:books?include_ids=12,12,34")["include_ids"] == ["12", "34"]
+
+
+def test_parse_bookstack_defaults_to_books_with_include_ids():
+    parsed = parse_bookstack_source("bookstack:?include_ids=12")
+    assert parsed["scope"] == "books"
+    assert parsed["include_ids"] == ["12"]
 
 
 def test_parse_bookstack_pages_books_fallback():
-    parsed = parse_bookstack_source("bookstack:12?scope=pages&output=books")
+    parsed = parse_bookstack_source("bookstack:pages?output=books")
     assert parsed["output"] == "pages"
 
 
 def test_parse_bookstack_accepts_chapter_output():
-    parsed = parse_bookstack_source("bookstack:12?scope=books&output=chapters")
+    parsed = parse_bookstack_source("bookstack:books?output=chapters")
     assert parsed["output"] == "chapters"
 
 
 def test_parse_bookstack_pages_chapters_fallback():
-    parsed = parse_bookstack_source("bookstack:12?scope=pages&output=chapters")
+    parsed = parse_bookstack_source("bookstack:pages?output=chapters")
     assert parsed["output"] == "pages"
 
 
@@ -47,8 +55,13 @@ def test_parse_bookstack_pages_chapters_fallback():
     "source",
     [
         "bookstack:abc",
-        "bookstack:12,,34",
-        "bookstack:?scope=book",
+        "bookstack:12",
+        "bookstack:books?include_ids=",
+        "bookstack:books?exclude_ids=",
+        "bookstack:books?include_ids=abc",
+        "bookstack:books?include_ids=12,,34",
+        "bookstack:books?include_ids=12&exclude_ids=34",
+        "bookstack:?scope=books",
         "bookstack:?output=chapter",
         "bookstack:?format=markdown",
         "bookstack:?format=zip",
@@ -85,13 +98,38 @@ def test_default_manifest_lists_books_then_pages_as_markdown():
     assert http.calls[2][0] == "/api/pages/99/export/markdown"
 
 
+def test_books_scope_excludes_ids():
+    http = FakeHTTP({
+        "/api/books": Response(
+            200,
+            json={
+                "data": [
+                    {"id": 12, "name": "Guide", "updated_at": "2026-01-01"},
+                    {"id": 13, "name": "Handbook", "updated_at": "2026-01-01"},
+                ]
+            },
+        ),
+        "/api/pages": Response(200, json={"data": [{"id": 99, "book_id": 13, "name": "Install", "updated_at": "2026-01-02"}]}),
+    })
+
+    connector = _connector(exclude_ids=["12"])
+    connector._http = http
+    try:
+        manifest = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert manifest[0].filename == "99_Install.md"
+    assert http.calls[1] == ("/api/pages", {"count": 100, "offset": 0, "filter[book_id]": "13"})
+
+
 def test_pages_scope_with_ids_reads_pages_directly_as_plaintext():
     http = FakeHTTP({
         "/api/pages/99": Response(200, json={"id": 99, "name": "Install", "updated_at": "2026-01-02"}),
         "/api/pages/99/export/plaintext": Response(200, content=b"Install"),
     })
 
-    connector = _connector(ids=["99"], scope="pages", export_format="txt")
+    connector = _connector(include_ids=["99"], scope="pages", export_format="txt")
     connector._http = http
     try:
         manifest = connector.build_manifest()
@@ -110,7 +148,7 @@ def test_books_scope_outputs_books_as_pdf():
         "/api/books/12/export/pdf": Response(200, content=b"%PDF"),
     })
 
-    connector = _connector(ids=["12"], export_output="books", export_format="pdf", structure="hierarchical")
+    connector = _connector(include_ids=["12"], export_output="books", export_format="pdf", structure="hierarchical")
     connector._http = http
     try:
         manifest = connector.build_manifest()
@@ -131,7 +169,7 @@ def test_hierarchical_pages_use_book_and_chapter_paths():
         "/api/chapters/7": Response(200, json={"id": 7, "name": "Setup"}),
     })
 
-    connector = _connector(ids=["12"], structure="hierarchical")
+    connector = _connector(include_ids=["12"], structure="hierarchical")
     connector._http = http
     try:
         manifest = connector.build_manifest()
@@ -157,7 +195,7 @@ def test_shelves_dedupe_books_and_use_shelf_path_for_book_output():
         "/api/books/12": Response(200, json={"id": 12, "name": "Guide", "updated_at": "2026-01-01"}),
     })
 
-    connector = _connector(ids=["5"], scope="shelves", export_output="books", structure="hierarchical")
+    connector = _connector(include_ids=["5"], scope="shelves", export_output="books", structure="hierarchical")
     connector._http = http
     try:
         manifest = connector.build_manifest()
@@ -198,8 +236,8 @@ def test_book_output_checksum_includes_nested_page_updates():
     old_http = FakeHTTP({"/api/books/12": Response(200, json=old_book)})
     new_http = FakeHTTP({"/api/books/12": Response(200, json=new_book)})
 
-    old_connector = _connector(ids=["12"], export_output="books")
-    new_connector = _connector(ids=["12"], export_output="books")
+    old_connector = _connector(include_ids=["12"], export_output="books")
+    new_connector = _connector(include_ids=["12"], export_output="books")
     old_connector._http = old_http
     new_connector._http = new_http
     try:
@@ -247,7 +285,7 @@ def test_chapter_output_uses_book_contents_and_keeps_standalone_pages():
         "/api/pages/101/export/markdown": Response(200, content=b"# Standalone"),
     })
 
-    connector = _connector(ids=["12"], export_output="chapters")
+    connector = _connector(include_ids=["12"], export_output="chapters")
     connector._http = http
     try:
         manifest = connector.build_manifest()
@@ -287,7 +325,7 @@ def test_shelf_chapter_output_uses_shelf_and_book_path():
         ),
     })
 
-    connector = _connector(ids=["5"], scope="shelves", export_output="chapters", structure="hierarchical")
+    connector = _connector(include_ids=["5"], scope="shelves", export_output="chapters", structure="hierarchical")
     connector._http = http
     try:
         manifest = connector.build_manifest()
@@ -330,8 +368,8 @@ def test_chapter_output_checksum_includes_nested_page_updates():
     old_http = FakeHTTP({"/api/books/12": Response(200, json=old_book)})
     new_http = FakeHTTP({"/api/books/12": Response(200, json=new_book)})
 
-    old_connector = _connector(ids=["12"], export_output="chapters")
-    new_connector = _connector(ids=["12"], export_output="chapters")
+    old_connector = _connector(include_ids=["12"], export_output="chapters")
+    new_connector = _connector(include_ids=["12"], export_output="chapters")
     old_connector._http = old_http
     new_connector._http = new_http
     try:
@@ -349,7 +387,7 @@ def test_shelf_without_books_returns_empty_manifest():
         "/api/shelves/5": Response(200, json={"id": 5, "name": "Empty", "books": []}),
     })
 
-    connector = _connector(ids=["5"], scope="shelves", export_output="books")
+    connector = _connector(include_ids=["5"], scope="shelves", export_output="books")
     connector._http = http
     try:
         manifest = connector.build_manifest()
@@ -391,7 +429,7 @@ def test_shelves_scope_outputs_hierarchical_pages():
         "/api/chapters/7": Response(200, json={"id": 7, "name": "Setup"}),
     })
 
-    connector = _connector(ids=["5"], scope="shelves", structure="hierarchical")
+    connector = _connector(include_ids=["5"], scope="shelves", structure="hierarchical")
     connector._http = http
     try:
         manifest = connector.build_manifest()
@@ -440,7 +478,7 @@ def test_format_mapping_for_book_exports(fmt, extension, export_name):
         f"/api/books/12/export/{export_name}": Response(200, content=b"content"),
     })
 
-    connector = _connector(ids=["12"], export_output="books", export_format=fmt)
+    connector = _connector(include_ids=["12"], export_output="books", export_format=fmt)
     connector._http = http
     try:
         manifest = connector.build_manifest()


### PR DESCRIPTION
## Summary

Adds configurable BookStack export options for selecting the source scope, included or excluded IDs, output type, file format, and path structure. The source path now selects the BookStack scope, while query parameters handle filtering and export options, leaving room for future filters such as tags.

This supersedes #80 and #82 and includes the combined BookStack export changes in one PR.

Addresses #75.

## What Changed

- Adds BookStack source scopes via the source path:
  - `bookstack:pages`
  - `bookstack:books`
  - `bookstack:shelves`
  - `bookstack:` defaults to `bookstack:books`
 - Adds BookStack source options:
  - `include_ids=12,34`
  - `exclude_ids=12,34`
  - `output=pages|chapters|books`
  - `format=txt|md|html|pdf`
  - `structure=flat|hierarchical`
- Uses BookStack native export endpoints for pages, chapters, and books.
- Supports syncing:
  - individual pages
  - pages from books
  - chapter exports from books, while keeping pages outside chapters as individual page exports
  - whole book exports
  - pages, chapters, or books from shelves
- Adds hierarchical paths for shelf/book/chapter structure where available.
- Updates BookStack checksums so whole-book and chapter exports change when nested page content changes.
- Adds BookStack parser and connector tests.
- Documents the new BookStack options in the guide.

## Examples

```bash
# Sync all pages from all BookStack books as Markdown files.
oikb sync bookstack: --kb-id your-kb-id

# Sync one specific BookStack page.
oikb sync 'bookstack:pages?include_ids=12' --kb-id your-kb-id

# Sync one BookStack book as chapter files; pages outside chapters remain page files.
oikb sync 'bookstack:books?include_ids=12&output=chapters' --kb-id your-kb-id

# Sync one whole BookStack book as a PDF file.
oikb sync 'bookstack:books?include_ids=12&output=books&format=pdf' --kb-id your-kb-id

# Sync all pages from one shelf and preserve shelf/book/chapter paths.
oikb sync 'bookstack:shelves?include_ids=5&structure=hierarchical' --kb-id your-kb-id
```

## Validation

- pytest: 40 passed
- compileall -f src/oikb tests: passed
- git diff --check: passed
- Live BookStack diff checks:
  - page scope
  - default book pages
  - chapter exports from book contents
  - whole-book markdown/html/pdf exports
  - plaintext exports
  - hierarchical shelf pages
  - hierarchical shelf book exports
- Live upload/idempotency checks:
  - single page sync, then unchanged repeat
  - whole-book sync, then unchanged repeat
  - chapter export sync, then unchanged repeat
  - hierarchical shelf sync, then unchanged repeat