### PR TITLE
fix(daemon): shut down cleanly in docker

### DIFF
--- a/src/oikb/daemon.py
+++ b/src/oikb/daemon.py
@@ -7,6 +7,7 @@ import hmac
 import logging
 import os
 import signal
+import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -50,6 +51,7 @@ _history: SyncHistory | None = None
 _entries: list[dict] = []
 _shutdown_event: asyncio.Event | None = None
 _scheduler_task: asyncio.Task | None = None
+_sync_stop_event = threading.Event()
 
 
 # ── Interval / cron parser ───────────────────────────────────────
@@ -264,11 +266,12 @@ async def _run_entry(entry: dict, dry_run: bool = False) -> dict | None:
 async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
     """Inner sync logic, called under the per-KB lock."""
     from oikb.cli import _make_client, _resolve_connector
-    from oikb.sync import run_sync
+    from oikb.sync import SyncCancelled, run_sync
 
     source = entry["source"]
     kb_id = entry["kb-id"]
     started_at = time.time()
+    client = None
 
     _scheduler_state[source] = {
         **_scheduler_state.get(source, {}),
@@ -310,8 +313,8 @@ async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
             quiet=True,
             manifest_filter=mf,
             concurrency=entry.get("concurrency", 1),
+            should_stop=_sync_stop_event.is_set,
         )
-        client.close()
 
         if dry_run:
             return {
@@ -376,6 +379,16 @@ async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
             "errors": result.errors or [],
         })
 
+    except SyncCancelled:
+        _scheduler_state[source] = {
+            "name": entry.get("name", source),
+            "status": "cancelled",
+            "last_sync": time.time(),
+        }
+        log.info(f"Sync cancelled during shutdown: {source}")
+        if dry_run:
+            return {"cancelled": True}
+
     except Exception as e:
         _scheduler_state[source] = {
             "name": entry.get("name", source),
@@ -405,6 +418,10 @@ async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
             "status": "error",
             "error": str(e),
         })
+
+    finally:
+        if client:
+            client.close()
 
 
 async def _schedule_entry(entry: dict) -> None:
@@ -441,15 +458,22 @@ async def _schedule_entry(entry: dict) -> None:
             pass  # Time elapsed, run again.
 
 
+def _request_shutdown() -> None:
+    _sync_stop_event.set()
+    if _shutdown_event:
+        _shutdown_event.set()
+
+
 async def _run_scheduler(entries: list[dict], handle_signals: bool = False) -> None:
     """Start all sync tasks and wait for shutdown."""
     global _shutdown_event
+    _sync_stop_event.clear()
     _shutdown_event = asyncio.Event()
 
     if handle_signals:
         loop = asyncio.get_event_loop()
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, _shutdown_event.set)
+            loop.add_signal_handler(sig, _request_shutdown)
 
     tasks = [asyncio.create_task(_schedule_entry(e)) for e in entries]
 
@@ -505,10 +529,13 @@ def start_daemon(
 
         @app.on_event("shutdown")
         async def _shutdown():
-            if _shutdown_event:
-                _shutdown_event.set()
+            _request_shutdown()
             if _scheduler_task:
-                await _scheduler_task
+                try:
+                    await asyncio.wait_for(_scheduler_task, timeout=1)
+                except asyncio.TimeoutError:
+                    _scheduler_task.cancel()
+                    await asyncio.gather(_scheduler_task, return_exceptions=True)
 
         click.echo(f"oikb daemon listening on port {port}")
         click.echo(f"  {len(entries)} source(s) configured")
@@ -529,4 +556,5 @@ def start_daemon(
             host="0.0.0.0",
             port=port,
             log_level="warning",
+            timeout_graceful_shutdown=1,
         )

--- a/src/oikb/daemon.py
+++ b/src/oikb/daemon.py
@@ -49,6 +49,7 @@ _sync_locks: dict[str, asyncio.Lock] = {}
 _history: SyncHistory | None = None
 _entries: list[dict] = []
 _shutdown_event: asyncio.Event | None = None
+_scheduler_task: asyncio.Task | None = None
 
 
 # ── Interval / cron parser ───────────────────────────────────────
@@ -440,14 +441,15 @@ async def _schedule_entry(entry: dict) -> None:
             pass  # Time elapsed, run again.
 
 
-async def _run_scheduler(entries: list[dict]) -> None:
+async def _run_scheduler(entries: list[dict], handle_signals: bool = False) -> None:
     """Start all sync tasks and wait for shutdown."""
     global _shutdown_event
     _shutdown_event = asyncio.Event()
 
-    loop = asyncio.get_event_loop()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, _shutdown_event.set)
+    if handle_signals:
+        loop = asyncio.get_event_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, _shutdown_event.set)
 
     tasks = [asyncio.create_task(_schedule_entry(e)) for e in entries]
 
@@ -466,7 +468,7 @@ def start_daemon(
     log_format: str = "text",
 ) -> None:
     """Start the daemon with scheduler + optional HTTP server."""
-    global _history, _entries
+    global _history, _entries, _scheduler_task
 
     from oikb.logging import configure_logging
     configure_logging(log_format=log_format)
@@ -494,11 +496,19 @@ def start_daemon(
     webhook_entries = [e for e in entries if e.get("webhook")]
 
     if no_server:
-        asyncio.run(_run_scheduler(entries))
+        asyncio.run(_run_scheduler(entries, handle_signals=True))
     else:
         @app.on_event("startup")
         async def _startup():
-            asyncio.create_task(_run_scheduler(entries))
+            global _scheduler_task
+            _scheduler_task = asyncio.create_task(_run_scheduler(entries))
+
+        @app.on_event("shutdown")
+        async def _shutdown():
+            if _shutdown_event:
+                _shutdown_event.set()
+            if _scheduler_task:
+                await _scheduler_task
 
         click.echo(f"oikb daemon listening on port {port}")
         click.echo(f"  {len(entries)} source(s) configured")

--- a/src/oikb/sync.py
+++ b/src/oikb/sync.py
@@ -60,6 +60,10 @@ class SyncResult:
         return ", ".join(parts) if parts else "nothing to do"
 
 
+class SyncCancelled(Exception):
+    """Raised when daemon shutdown cancels an in-progress sync."""
+
+
 def parse_size(value: str | int | None) -> int | None:
     """Parse a human-readable size string to bytes.
 
@@ -135,6 +139,7 @@ def run_sync(
     quiet: bool = False,
     manifest_filter: Callable[[list[ManifestEntry]], list[ManifestEntry]] | None = None,
     concurrency: int = 1,
+    should_stop: Callable[[], bool] | None = None,
 ) -> SyncResult:
     """Execute a full incremental sync.
 
@@ -152,7 +157,7 @@ def run_sync(
     try:
         return _run_sync_inner(
             client, connector, kb_id, dry_run, verbose, quiet,
-            manifest_filter, concurrency, result,
+            manifest_filter, concurrency, result, should_stop,
         )
     finally:
         connector.close()
@@ -168,11 +173,17 @@ def _run_sync_inner(
     manifest_filter: Callable[[list[ManifestEntry]], list[ManifestEntry]] | None,
     concurrency: int,
     result: SyncResult,
+    should_stop: Callable[[], bool] | None,
 ) -> SyncResult:
     """Inner sync logic, separated for clean connector cleanup."""
     show_progress = not quiet and not dry_run
 
+    def check_stop() -> None:
+        if should_stop and should_stop():
+            raise SyncCancelled("Sync cancelled during shutdown")
+
     # ── 1. Build manifest ──────────────────────────────────────
+    check_stop()
     if show_progress:
         with _console.status("[bold blue]Scanning source..."):
             manifest = connector.build_manifest()
@@ -183,6 +194,8 @@ def _run_sync_inner(
         manifest = connector.build_manifest()
         if verbose:
             click.echo(f"  {len(manifest)} files found", err=True)
+
+    check_stop()
 
     # ── 2. Apply filter ────────────────────────────────────────
     if manifest_filter:
@@ -198,6 +211,7 @@ def _run_sync_inner(
         return result
 
     # ── 3. Compute diff ────────────────────────────────────────
+    check_stop()
     if show_progress:
         with _console.status("[bold blue]Computing diff..."):
             diff = client.sync_diff(kb_id, [e.to_dict() for e in manifest])
@@ -274,6 +288,7 @@ def _run_sync_inner(
     ]
 
     if stale_file_ids or rmdir:
+        check_stop()
         if show_progress:
             with _console.status(f"[bold blue]Cleaning up {len(stale_file_ids)} stale files..."):
                 client.sync_cleanup(kb_id, stale_file_ids, rmdir if rmdir else None)
@@ -289,6 +304,7 @@ def _run_sync_inner(
 
     # ── 5. Create missing directories ──────────────────────────
     for dir_path in mkdir:
+        check_stop()
         segments = dir_path.split("/")
         name = segments[-1]
         parent_path = "/".join(segments[:-1])
@@ -320,6 +336,8 @@ def _run_sync_inner(
         path = entry.get("path", "")
         display = f"{path}/{filename}" if path else filename
 
+        check_stop()
+
         if verbose and not progress:
             click.echo(f"  [{i}/{len(files_to_upload)}] {display}", err=True)
 
@@ -329,8 +347,10 @@ def _run_sync_inner(
 
         last_err: Exception | None = None
         for attempt in range(3):
+            check_stop()
             try:
                 content = connector.read_file(path, filename)
+                check_stop()
                 directory_id = directory_map.get(path) if path else None
                 client.upload_file(
                     file_content=content,
@@ -345,10 +365,13 @@ def _run_sync_inner(
             except httpx.HTTPStatusError as e:
                 if e.response.status_code >= 500 and attempt < 2:
                     time.sleep(2 ** attempt)
+                    check_stop()
                     last_err = e
                     continue
                 last_err = e
                 break
+            except SyncCancelled:
+                raise
             except Exception as e:
                 last_err = e
                 break
@@ -385,6 +408,7 @@ def _run_sync_inner(
             task_id = progress.add_task("", total=len(files_to_upload))
 
             if concurrency > 1 and len(files_to_upload) > 1:
+                check_stop()
                 with ThreadPoolExecutor(max_workers=concurrency) as pool:
                     futures = {
                         pool.submit(_upload_one, i, entry, ct, progress, task_id): (entry, ct)
@@ -394,10 +418,12 @@ def _run_sync_inner(
                         _tally(future.result())
             else:
                 for i, (entry, change_type) in enumerate(files_to_upload, 1):
+                    check_stop()
                     _tally(_upload_one(i, entry, change_type, progress, task_id))
     else:
         # Quiet or daemon mode — no progress bar.
         if concurrency > 1 and len(files_to_upload) > 1:
+            check_stop()
             with ThreadPoolExecutor(max_workers=concurrency) as pool:
                 futures = {
                     pool.submit(_upload_one, i, entry, ct, None, None): (entry, ct)
@@ -407,6 +433,7 @@ def _run_sync_inner(
                     _tally(future.result())
         else:
             for i, (entry, change_type) in enumerate(files_to_upload, 1):
+                check_stop()
                 _tally(_upload_one(i, entry, change_type, None, None))
 
     return result


### PR DESCRIPTION
## Summary

Fixes daemon shutdown so Docker restarts/stops do not wait for the 10s kill timeout.

The daemon now leaves SIGTERM/SIGINT handling to Uvicorn in server mode, stops the scheduler through FastAPI shutdown, and passes a cooperative shutdown signal into active sync runs.

## What Changed

- Preserve Uvicorn signal handling in server mode.
- Keep scheduler-owned signal handling only for `--no-server`.
- Stop the scheduler during FastAPI shutdown.
- Add cooperative cancellation to `run_sync`.
- Stop new cleanup, directory creation, and upload work once shutdown is requested.
- Set a short Uvicorn graceful shutdown timeout as a fallback for blocking work.

## Validation

- `compileall -f src/oikb/daemon.py src/oikb/sync.py`
- `git diff --check`
- Local `run_sync(..., should_stop=...)` cancellation smoke test
- Docker shutdown test: normal stop exits in ~1s
- Docker shutdown test with blocked sync request exits before Docker's 10s kill timeout
- Live Docker restart test confirmed working