### PR TITLE
fix: read KB files from /knowledge/{id}/files endpoint (#89)

### DIFF
--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -758,7 +758,7 @@ def status(url: str | None, token: str | None, kb: str | None):
 
     try:
         info = client.get_kb(kb)
-        files = info.get("files", [])
+        files = client.list_kb_files(kb)
     except Exception as e:
         click.echo(click.style(f"Failed: {e}", fg="red"), err=True)
         sys.exit(1)
@@ -937,7 +937,7 @@ def validate(config_file: str | None, deep: bool):
             try:
                 kb = client.get_kb(kb_id)
                 kb_name = kb.get("name", "?")
-                file_count = len(kb.get("files", []))
+                file_count = client.count_kb_files(kb_id)
                 click.echo(
                     click.style(f"  ✓ {entry_name}", fg="green")
                     + f"  {source} → {kb_name} ({file_count} files)"

--- a/src/oikb/client.py
+++ b/src/oikb/client.py
@@ -125,14 +125,25 @@ class OikbClient:
         return resp.json()
 
     def get_kb(self, kb_id: str) -> dict[str, Any]:
-        """GET /knowledge/{id} — get KB info."""
+        """GET /knowledge/{id} — get KB metadata.
+
+        Note: this endpoint returns metadata only. Its ``files`` field is a
+        server-hydrated convenience that some Open WebUI versions return as
+        null; use ``list_kb_files``/``count_kb_files`` for the file list.
+        """
         resp = self._http.get(f"/knowledge/{kb_id}")
         resp.raise_for_status()
         return resp.json()
 
     def list_kb_files(self, kb_id: str) -> list[dict[str, Any]]:
         """GET /knowledge/{id}/files — list files in a KB."""
-        resp = self._http.get(f"/knowledge/{kb_id}")
+        resp = self._http.get(f"/knowledge/{kb_id}/files")
         resp.raise_for_status()
         data = resp.json()
-        return data.get("files", [])
+        return data.get("items", [])
+
+    def count_kb_files(self, kb_id: str) -> int:
+        """GET /knowledge/{id}/files — total file count for a KB."""
+        resp = self._http.get(f"/knowledge/{kb_id}/files")
+        resp.raise_for_status()
+        return resp.json().get("total", 0)


### PR DESCRIPTION
`validate --deep`, `status`, and `ls` derived the KB file list from `GET /knowledge/{id}`, whose `files` field is a server-hydrated convenience that Open WebUI version 0.11.0 returns as null. Reading `len(kb.get("files", []))` then crashed with "object of type 'NoneType' has no len()" because .get()'s default only applies to a missing key, not an explicit null. `ls` silently printed "(empty)" for the same reason. Sync was unaffected as it uses the server-side /sync/diff endpoint.

Point the file listing at the real `GET /knowledge/{id}/files` endpoint (returns {items, total}): fix list_kb_files, add count_kb_files for the authoritative total, and use them in the affected commands.

Fixes #89