### PR TITLE
Fix: Increased outline document limit

### DIFF
--- a/src/oikb/connectors/outline.py
+++ b/src/oikb/connectors/outline.py
@@ -27,26 +27,54 @@ class OutlineConnector(BaseConnector):
         self._cache: dict[str, str] = {}
 
     def build_manifest(self) -> list[ManifestEntry]:
-        params: dict = {"limit": 100}
+        # Resolve collection ID once before starting the loop
+        collection_id = None
         if self._collection:
-            # Resolve collection by name.
-            cols = self._http.post("/api/collections.list", json={}).json().get("data", [])
+            cols_resp = self._http.post("/api/collections.list", json={})
+            cols_resp.raise_for_status()
+            cols = cols_resp.json().get("data", [])
             col = next((c for c in cols if c.get("name") == self._collection or c.get("id") == self._collection), None)
             if col:
-                params["collectionId"] = col["id"]
+                collection_id = col["id"]
 
-        resp = self._http.post("/api/documents.list", json=params)
-        resp.raise_for_status()
-        docs = resp.json().get("data", [])
         entries: list[ManifestEntry] = []
-        for doc in docs:
-            title = doc.get("title", "untitled")
-            text = doc.get("text", "")
-            content = f"# {title}\n\n{text}"
-            filename = f"{doc['id']}.md"
-            checksum = hashlib.sha256(content.encode()).hexdigest()[:16]
-            entries.append(ManifestEntry(filename=filename, path="", checksum=checksum, size=len(content.encode())))
-            self._cache[filename] = content
+        offset = 0
+        limit = 100  # The maximum allowed by the server per request
+
+        while True:
+            # Use 'offset' instead of 'page' as per the API spec
+            params: dict = {
+                "offset": offset,
+                "limit": limit,
+                "sort": "updatedAt",
+                "direction": "DESC"
+            }
+            if collection_id:
+                params["collectionId"] = collection_id
+
+            resp = self._http.post("/api/documents.list", json=params)
+            resp.raise_for_status()
+            docs = resp.json().get("data", [])
+
+            if not docs:
+                break
+
+            for doc in docs:
+                title = doc.get("title", "untitled")
+                text = doc.get("text", "")
+                content = f"# {title}\n\n{text}"
+                filename = f"{doc['id']}.md"
+                checksum = hashlib.sha256(content.encode()).hexdigest()[:16]
+                entries.append(ManifestEntry(filename=filename, path="", checksum=checksum, size=len(content.encode())))
+                self._cache[filename] = content
+
+            # If we received fewer than the limit, we've reached the end of the list
+            if len(docs) < limit:
+                break
+
+            # Increment offset by the number of items retrieved to get the next batch
+            offset += limit
+
         return entries
 
     def read_file(self, path: str, filename: str) -> bytes:


### PR DESCRIPTION
The outline connector previously returned only 100 documents. This change uses documents.list [offset](https://www.getoutline.com/developers#tag/documents/post/documentslist) to list  more than 100 documents.