### PR TITLE
Confluence: keep the text held in macro bodies, skip pages that have none

### DIFF
--- a/src/oikb/connectors/confluence.py
+++ b/src/oikb/connectors/confluence.py
@@ -14,17 +14,56 @@ from typing import Any
 
 import httpx
 
-from oikb.connectors import BaseConnector, ManifestEntry
+from oikb.connectors import BaseConnector, ManifestEntry, SourceFileUnavailable
+
+# A link's visible label is the title of another page in the space, which syncs
+# as its own file. Dropped with the link so a section index does not become a
+# document that is nothing but titles already in the KB.
+_LINK_BODY = re.compile(
+    r"<ac:plain-text-link-body>.*?</ac:plain-text-link-body>", re.S | re.I
+)
+_CDATA = re.compile(r"<!\[CDATA\[(.*?)\]\]>", re.S)
+# Where one block ends the next begins on its own line: a code block run
+# together with the sentence before it reads as one thought.
+_BREAK = re.compile(
+    r"<br\s*/?>"
+    r"|</(?:p|div|h[1-6]|li|ul|ol|tr|td|th|blockquote|pre|table|section)\s*>"
+    r"|</ac:[\w.-]+\s*>",
+    re.I,
+)
+_TAG = re.compile(r"<[^>]+>")
+# Marks where a parked macro body goes back. Storage format cannot contain NUL.
+_PARKED = re.compile("\x00(\\d+)\x00")
+_INLINE_SPACE = re.compile(r"[^\S\n]+")
 
 
 def _storage_to_text(storage_html: str) -> str:
     """Convert Confluence storage format (XHTML) to plain text."""
-    # Strip all HTML tags.
-    text = re.sub(r"<[^>]+>", " ", storage_html)
+    if not storage_html:
+        return ""
+
+    text = _LINK_BODY.sub(" ", storage_html)
+
+    # Macro bodies are literal text, so they are parked before the markup passes
+    # run: `<[^>]+>` would otherwise treat `<![CDATA[...]]>` as one tag and
+    # delete a code block or panel whole, and their entities are not escaped.
+    parked: list[str] = []
+
+    def _park(match: re.Match) -> str:
+        parked.append(match.group(1))
+        return f"\n\x00{len(parked) - 1}\x00\n"
+
+    text = _CDATA.sub(_park, text)
+    text = _BREAK.sub("\n", text)
+    text = _TAG.sub(" ", text)
     text = html.unescape(text)
-    # Collapse whitespace.
-    text = re.sub(r"\s+", " ", text).strip()
-    return text
+
+    lines = (_INLINE_SPACE.sub(" ", line).strip() for line in text.split("\n"))
+    text = "\n".join(line for line in lines if line)
+
+    # Restored after the whitespace pass so a code block keeps its own line
+    # breaks and indentation.
+    return _PARKED.sub(lambda m: parked[int(m.group(1))].strip(), text).strip()
 
 
 class ConfluenceConnector(BaseConnector):
@@ -141,6 +180,14 @@ class ConfluenceConnector(BaseConnector):
 
         storage = data.get("body", {}).get("storage", {}).get("value", "")
         text = _storage_to_text(storage)
+        if not text:
+            # Open WebUI extracts text as part of POST /files/ and answers 400
+            # for a file it can get nothing out of, so uploading this would fail
+            # the page on every run for as long as it exists.
+            raise SourceFileUnavailable(
+                "page has no text to sync (blank, or only a macro such as a "
+                "children index)"
+            )
         return text.encode("utf-8")
 
     def close(self) -> None:


### PR DESCRIPTION
Two bugs in the Confluence connector, found while syncing a 321-page space.

## 1. Macro bodies are deleted

`_storage_to_text` flattens a page with `re.sub(r"<[^>]+>", " ", storage_html)`. That regex treats `<![CDATA[...]]>` as one tag and removes it whole, so everything Confluence keeps in a macro body — code blocks, info and note panels, expand sections — never reaches the Knowledge Base.

The page still syncs. It is just quietly missing the part that was usually worth reading. In the space I checked, five pages were affected, the worst losing 1.3KB of a documented HTML snippet.

It also fails in the other direction: when the CDATA content itself contains `>`, the tag match ends early and the rest leaks into the output as text, along with a stray `]]>`.

Macro bodies are now parked before the markup passes and restored after the whitespace pass, so a code block keeps its own line breaks, indentation and angle brackets instead of having half of itself stripped as tags. Block ends become newlines too — output used to collapse onto a single line, which reads as one thought and chunks as one.

```python
>>> _storage_to_text('<p>Paste this:</p>' + code_block('SELECT 1;'))
'Paste this:\nSELECT 1;'      # was 'Paste this:'
```

Link labels are dropped along with their links: `<ac:plain-text-link-body>` holds the title of another page in the space, and that page syncs as its own file, so keeping labels turns every section index into a document that is nothing but titles already in the KB.

## 2. Pages with no text fail with a 400 on every run

That leaves pages which genuinely have no text — a blank page, or one holding only a children-display macro. They extract to zero bytes, and Open WebUI extracts text as part of `POST /files/` and answers a bare 400 for a file it can get nothing out of:

```
Homepage.txt: Client error '400 Bad Request' for url 'https://…/api/v1/files/'
Pricing.txt: Client error '400 Bad Request' for url 'https://…/api/v1/files/'
… 18 more
```

Twenty of the 321 pages were section indexes and archive stubs like this. Nothing about that resolves itself, so the space could never sync clean. `read_file` now raises `SourceFileUnavailable` for them, which `run_sync` already reports as a warning rather than an error.

## Validation

Both extractors run over all 321 pages of a real space:

```
empty before: 20   empty after: 20   (same set — the index stubs)
pages that gained text: 5
  +58 words — an HTML email signature in a code block
   +6 words — an info panel
   +2 words — a note panel
   +2 words — a note panel
   +1 words — an expand section
```

No page lost anything but the stray `]]>` fragments the old regex leaked. This has been running in production against that space since today.

## One thing I left alone

A Confluence checksum is built from the page version rather than the page text, so a space already synced picks up the better extraction only as pages are edited. Salting the manifest with an extractor version fixes that immediately — it is what I did downstream — but it re-uploads every page of every Confluence space on the first sync after upgrading, which felt like a maintainer's call rather than something to slip into this patch. Happy to add it if you want it.

There is no test suite in the repo, so I have not added one; glad to if you would like tests for this.