### PR TITLE
Confluence: preserve page hierarchy for tree filtering

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -247,9 +247,16 @@ Requires `GITLAB_TOKEN` or `BITBUCKET_TOKEN` respectively.
 
 ```bash
 oikb sync confluence:SPACE_KEY --kb-id your-kb-id
+
+# Preserve the Confluence page hierarchy in manifest paths.
+oikb sync 'confluence:SPACE_KEY?structure=hierarchical' --kb-id your-kb-id
 ```
 
-Requires `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, and `CONFLUENCE_API_TOKEN`.
+With hierarchical structure enabled, existing `filter.include` and
+`filter.exclude` patterns can select page trees, for example
+`Engineering/Runbooks*`.
+
+Requires `CONFLUENCE_URL`, `CONFLUENCE_USER`, and `CONFLUENCE_TOKEN`.
 
 ### BookStack
 

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -89,7 +89,11 @@ def _resolve_connector(source: str, branch: str | None = None, path: str | None 
     if source.startswith("confluence:"):
         from oikb.connectors.confluence import ConfluenceConnector, parse_confluence_source
         parsed = parse_confluence_source(source)
-        return ConfluenceConnector(space_key=parsed["space_key"], base_url=parsed.get("base_url"))
+        return ConfluenceConnector(
+            space_key=parsed["space_key"],
+            base_url=parsed.get("base_url"),
+            structure=parsed.get("structure", "flat"),
+        )
 
     if source.startswith("notion:"):
         from oikb.connectors.notion import NotionConnector, parse_notion_source

--- a/src/oikb/connectors/confluence.py
+++ b/src/oikb/connectors/confluence.py
@@ -11,6 +11,7 @@ import html
 import os
 import re
 from typing import Any
+from urllib.parse import parse_qsl, urlsplit
 
 import httpx
 
@@ -35,6 +36,7 @@ class ConfluenceConnector(BaseConnector):
         base_url:  Confluence instance URL (or CONFLUENCE_URL env var).
         user:      Confluence user email (or CONFLUENCE_USER env var).
         token:     Confluence API token (or CONFLUENCE_TOKEN env var).
+        structure: "flat" or "hierarchical" manifest paths.
     """
 
     def __init__(
@@ -43,8 +45,12 @@ class ConfluenceConnector(BaseConnector):
         base_url: str | None = None,
         user: str | None = None,
         token: str | None = None,
+        structure: str = "flat",
     ):
+        if structure not in {"flat", "hierarchical"}:
+            raise ValueError("structure must be 'flat' or 'hierarchical'")
         self.space_key = space_key
+        self.structure = structure
 
         self._base_url = (base_url or os.environ.get("CONFLUENCE_URL", "")).rstrip("/")
         self._user = user or os.environ.get("CONFLUENCE_USER", "")
@@ -68,12 +74,33 @@ class ConfluenceConnector(BaseConnector):
             timeout=60.0,
         )
 
+        # Resolve space key to numeric ID (v2 API requires ID).
+        if not self.space_key.isdecimal():
+            try:
+                resp = self._http.get(
+                    "/api/v2/spaces", params={"keys": [self.space_key]}
+                )
+                resp.raise_for_status()
+                results = resp.json().get("results", [])
+                matches = [
+                    space
+                    for space in results
+                    if space.get("key", "").casefold() == self.space_key.casefold()
+                ]
+                if len(matches) != 1:
+                    raise ValueError(f"Confluence space '{self.space_key}' not found")
+                self.space_key = str(matches[0]["id"])
+            except Exception:
+                self._http.close()
+                raise
+
         # Cache page content for read_file.
         self._page_cache: dict[str, str] = {}
 
     def build_manifest(self) -> list[ManifestEntry]:
         """List all pages in the space and build a manifest."""
-        entries: list[ManifestEntry] = []
+        self._page_cache.clear()
+        pages: list[dict[str, Any]] = []
         cursor = None
 
         while True:
@@ -88,30 +115,7 @@ class ConfluenceConnector(BaseConnector):
             resp.raise_for_status()
             data = resp.json()
 
-            for page in data.get("results", []):
-                page_id = page["id"]
-                title = page["title"]
-                version = page.get("version", {}).get("number", 0)
-
-                # Use version number as part of checksum.
-                checksum = hashlib.sha256(
-                    f"{page_id}:v{version}".encode()
-                ).hexdigest()[:16]
-
-                # Sanitize title for filename.
-                filename = re.sub(r'[<>:"/\\|?*]', "_", title) + ".txt"
-
-                entries.append(
-                    ManifestEntry(
-                        filename=filename,
-                        path="",
-                        checksum=checksum,
-                        size=0,
-                    )
-                )
-
-                # Store page ID for later retrieval.
-                self._page_cache[filename] = page_id
+            pages.extend(data.get("results", []))
 
             # Handle pagination.
             next_link = data.get("_links", {}).get("next")
@@ -123,12 +127,59 @@ class ConfluenceConnector(BaseConnector):
             if not cursor:
                 break
 
+        pages_by_id = {str(page["id"]): page for page in pages}
+        entries = [self._page_entry(page, pages_by_id) for page in pages]
         entries.sort(key=lambda e: e.display_path)
         return entries
 
+    def _page_entry(
+        self, page: dict[str, Any], pages_by_id: dict[str, dict[str, Any]]
+    ) -> ManifestEntry:
+        page_id = page["id"]
+        title = page["title"]
+        version = page.get("version", {}).get("number", 0)
+        checksum = hashlib.sha256(f"{page_id}:v{version}".encode()).hexdigest()[:16]
+        filename = self._safe_name(title) + ".txt"
+        path = self._page_path(page, pages_by_id)
+        cache_key = self._entry_key(path, filename)
+        if self.structure == "hierarchical" and cache_key in self._page_cache:
+            raise ValueError(f"Duplicate Confluence page path: {cache_key}")
+        self._page_cache[cache_key] = page_id
+        return ManifestEntry(filename=filename, path=path, checksum=checksum, size=0)
+
+    def _page_path(
+        self, page: dict[str, Any], pages_by_id: dict[str, dict[str, Any]]
+    ) -> str:
+        if self.structure != "hierarchical":
+            return ""
+
+        ancestors: list[str] = []
+        parent_id = page.get("parentId")
+        seen: set[str] = set()
+        while parent_id:
+            parent_id = str(parent_id)
+            if parent_id in seen:
+                raise ValueError(f"Circular Confluence page hierarchy at page {page['id']}")
+            seen.add(parent_id)
+            parent = pages_by_id.get(parent_id)
+            if not parent:
+                break
+            ancestors.append(self._safe_name(parent.get("title")))
+            parent_id = parent.get("parentId")
+        return "/".join(reversed(ancestors))
+
+    @staticmethod
+    def _safe_name(name: str | None) -> str:
+        safe = re.sub(r'[<>:"/\\|?*]', "_", name or "Untitled").strip()
+        return safe or "Untitled"
+
+    @staticmethod
+    def _entry_key(path: str, filename: str) -> str:
+        return f"{path}/{filename}" if path else filename
+
     def read_file(self, path: str, filename: str) -> bytes:
         """Fetch a page's content and return as text."""
-        page_id = self._page_cache.get(filename)
+        page_id = self._page_cache.get(self._entry_key(path, filename))
         if not page_id:
             raise FileNotFoundError(f"Page not found: {filename}")
 
@@ -153,14 +204,25 @@ def parse_confluence_source(source: str) -> dict[str, str | None]:
     Examples:
         confluence:ENG
         confluence:https://company.atlassian.net/ENG
+        confluence:ENG?structure=hierarchical
     """
     source = source.removeprefix("confluence:")
-
-    # Check if it includes a URL.
-    if source.startswith("https://"):
-        parts = source.rsplit("/", 1)
-        if len(parts) == 2:
-            return {"base_url": parts[0], "space_key": parts[1]}
+    is_url = source.startswith(("http://", "https://"))
+    parsed = urlsplit(source if is_url else f"confluence://{source}")
+    space_key = parsed.path.strip("/") if is_url else parsed.netloc
+    if not space_key or "/" in space_key:
         raise ValueError("Invalid Confluence source. Expected: confluence:SPACEKEY")
 
-    return {"space_key": source, "base_url": None}
+    params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    unknown = set(params) - {"structure"}
+    if unknown:
+        raise ValueError(f"Invalid Confluence source. Unknown parameter: {min(unknown)}")
+    structure = params.get("structure", "flat")
+    if structure not in {"flat", "hierarchical"}:
+        raise ValueError("Invalid Confluence source. Expected structure=flat or structure=hierarchical")
+
+    return {
+        "base_url": f"{parsed.scheme}://{parsed.netloc}" if is_url else None,
+        "space_key": space_key,
+        "structure": structure,
+    }

--- a/tests/test_confluence.py
+++ b/tests/test_confluence.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from oikb.connectors.confluence import ConfluenceConnector, parse_confluence_source
+from oikb.sync import build_manifest_filter
+
+
+def test_parse_hierarchical_source() -> None:
+    assert parse_confluence_source("confluence:ABC?structure=hierarchical") == {
+        "base_url": None,
+        "space_key": "ABC",
+        "structure": "hierarchical",
+    }
+
+
+def test_parse_url_source_with_structure() -> None:
+    assert parse_confluence_source(
+        "https://company.atlassian.net/ABC?structure=hierarchical"
+    ) == {
+        "base_url": "https://company.atlassian.net",
+        "space_key": "ABC",
+        "structure": "hierarchical",
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "confluence:ABC?structure=invalid",
+        "confluence:ABC?unexpected=value",
+    ],
+)
+def test_parse_rejects_invalid_structure(source: str) -> None:
+    with pytest.raises(ValueError):
+        parse_confluence_source(source)
+
+
+@respx.mock
+def test_resolves_space_key_to_id() -> None:
+    lookup = respx.get("https://test.atlassian.net/wiki/api/v2/spaces").mock(
+        return_value=httpx.Response(
+            200, json={"results": [{"id": "123456789", "key": "ABC"}]}
+        )
+    )
+    pages = respx.get(
+        "https://test.atlassian.net/wiki/api/v2/spaces/123456789/pages"
+    ).mock(return_value=httpx.Response(200, json={"results": []}))
+
+    connector = ConfluenceConnector(
+        space_key="ABC", base_url="https://test.atlassian.net", token="token"
+    )
+    try:
+        assert connector.build_manifest() == []
+    finally:
+        connector.close()
+
+    assert lookup.calls[0].request.url.params["keys"] == "ABC"
+    assert pages.called
+
+
+@respx.mock
+def test_rejects_mismatched_space_lookup() -> None:
+    respx.get("https://test.atlassian.net/wiki/api/v2/spaces").mock(
+        return_value=httpx.Response(
+            200, json={"results": [{"id": "123456789", "key": "OTHER"}]}
+        )
+    )
+
+    with pytest.raises(ValueError, match="Confluence space 'ABC' not found"):
+        ConfluenceConnector(
+            space_key="ABC",
+            base_url="https://test.atlassian.net",
+            token="token",
+        )
+
+
+def _pages() -> list[dict[str, object]]:
+    return [
+        {"id": "1", "title": "FAQ", "version": {"number": 1}},
+        {
+            "id": "2",
+            "title": "Benefits",
+            "parentId": "1",
+            "version": {"number": 2},
+        },
+        {"id": "3", "title": "Internal Notes", "version": {"number": 1}},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("structure", "expected"),
+    [
+        ("flat", ["Benefits.txt", "FAQ.txt", "Internal Notes.txt"]),
+        ("hierarchical", ["FAQ.txt", "FAQ/Benefits.txt", "Internal Notes.txt"]),
+    ],
+)
+@respx.mock
+def test_manifest_in_both_modes(structure: str, expected: list[str]) -> None:
+    respx.get(
+        "https://test.atlassian.net/wiki/api/v2/spaces/123456789/pages"
+    ).mock(return_value=httpx.Response(200, json={"results": _pages()}))
+
+    connector = ConfluenceConnector(
+        space_key="123456789",
+        base_url="https://test.atlassian.net",
+        token="token",
+        structure=structure,
+    )
+    try:
+        manifest = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert [entry.display_path for entry in manifest] == expected
+
+
+@respx.mock
+def test_hierarchical_paths_work_with_filter_and_read_file() -> None:
+    respx.get(
+        "https://test.atlassian.net/wiki/api/v2/spaces/123456789/pages"
+    ).mock(return_value=httpx.Response(200, json={"results": _pages()}))
+    content = respx.get("https://test.atlassian.net/wiki/api/v2/pages/2").mock(
+        return_value=httpx.Response(
+            200, json={"body": {"storage": {"value": "<p>Benefits</p>"}}}
+        )
+    )
+
+    connector = ConfluenceConnector(
+        space_key="123456789",
+        base_url="https://test.atlassian.net",
+        token="token",
+        structure="hierarchical",
+    )
+    try:
+        manifest = connector.build_manifest()
+        selected = build_manifest_filter(include=["FAQ*"])(manifest)
+        assert [entry.display_path for entry in selected] == [
+            "FAQ.txt",
+            "FAQ/Benefits.txt",
+        ]
+        assert connector.read_file("FAQ", "Benefits.txt") == b"Benefits"
+    finally:
+        connector.close()
+
+    assert content.called
+
+
+@respx.mock
+def test_hierarchical_mode_rejects_duplicate_paths() -> None:
+    pages = [
+        {"id": "1", "title": "FAQ", "version": {"number": 1}},
+        {"id": "2", "title": "FAQ", "version": {"number": 1}},
+    ]
+    respx.get(
+        "https://test.atlassian.net/wiki/api/v2/spaces/123456789/pages"
+    ).mock(return_value=httpx.Response(200, json={"results": pages}))
+    connector = ConfluenceConnector(
+        space_key="123456789",
+        base_url="https://test.atlassian.net",
+        token="token",
+        structure="hierarchical",
+    )
+
+    try:
+        with pytest.raises(ValueError, match="Duplicate Confluence page path"):
+            connector.build_manifest()
+    finally:
+        connector.close()
+
+
+@respx.mock
+def test_manifest_can_be_built_repeatedly() -> None:
+    respx.get(
+        "https://test.atlassian.net/wiki/api/v2/spaces/123456789/pages"
+    ).mock(return_value=httpx.Response(200, json={"results": _pages()}))
+    connector = ConfluenceConnector(
+        space_key="123456789",
+        base_url="https://test.atlassian.net",
+        token="token",
+        structure="hierarchical",
+    )
+
+    try:
+        first = connector.build_manifest()
+        second = connector.build_manifest()
+    finally:
+        connector.close()
+
+    assert first == second


### PR DESCRIPTION
## Why

Confluence pages are currently synchronized using only their page titles. This loses the page hierarchy and makes it impossible to use existing include/exclude filters to select a page tree.

For example, users cannot reliably select only a subtree without synchronizing the entire space.

## What

Add an optional hierarchical structure mode:

```text
confluence:ABC?structure=hierarchical
```

In this mode, page paths include their full Confluence hierarchy:

```text
Knowledge Base and FAQ/FAQ - Using OpenCode.txt
```

The root page itself is represented as:

```text
Knowledge Base and FAQ.txt
```

Existing filters can select a subtree:

```yaml
source: "confluence:ABC?structure=hierarchical"
filter:
  include:
    - "Knowledge Base and FAQ/**"
```

The default flat mode remains unchanged.
Thus, there is **full backwards compatibility**.

## Changes

- Add `structure=hierarchical` source configuration.
- Build paths from Confluence page `parentId` relationships.
- Resolve non-numeric space keys to numeric Confluence space IDs.
- Keep page content lookup correct for hierarchical paths.
- Reject ambiguous page paths instead of syncing the wrong page.
- Add mocked tests for parsing, both modes, filtering, page reads, key resolution, collisions, and repeated manifest builds.
- Update the Confluence documentation.

## Verification

- 11 tests passed.
- Python compilation passed.
- `git diff --check` passed.
