### PR TITLE
fix: stop re-upload loop for files rejected during server-side ingestion (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Sync loops on failed ingestion**: files that Open WebUI rejects during ingestion were re-uploaded on every sync cycle, accumulating orphaned file records and disk usage server-side (#106). oikb now records permanently rejected uploads (HTTP 4xx) in its state database and skips them until the source file's checksum changes. Since uploads are ingested asynchronously (HTTP 200, then silent failure), accepted uploads are also tracked: when the diff reports a tracked file again, oikb checks its server-side processing status instead of re-uploading — failed ingestions become permanent skips, files still processing are skipped for that run, and processed-but-unlinked files are re-linked in place instead of being uploaded again.
+
+### Added
+
+- **`oikb failures` command**: list uploads that were permanently rejected by the server (`--kb-id` to filter, `--clear` to forget the records and retry them on the next sync, `--json` for machine-readable output).
+
 ## [0.4.0] - 2026-07-17
 
 ### Added

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -803,6 +803,8 @@ oikb status --kb-id ID              Show KB info
 oikb history                        View sync history
 oikb history --json                 JSON output
 oikb history --errors               Failed syncs only
+oikb failures                       List permanently rejected files
+oikb failures --clear               Forget rejections (retried next sync)
 oikb reset --kb-id ID               Delete all files in a KB
 oikb config set url <url>           Save Open WebUI URL
 oikb config set token <token>       Save API key
@@ -842,6 +844,22 @@ You're running `oikb sync` without arguments and there's no `.oikb.yaml` in the 
 oikb validate        # Check config syntax
 oikb validate --deep # Verify API + KB connectivity
 ```
+
+### Files show as "skipped (known failures)"
+
+Open WebUI rejects some files during ingestion — e.g. documents whose extracted
+text is identical to a file already in the KB, or files with no extractable text.
+Because the server processes uploads asynchronously, such files never get linked
+to the KB and would otherwise be re-uploaded on every sync cycle. oikb records
+these rejections and skips the files until their content changes.
+
+```bash
+oikb failures           # which files are affected, and why
+oikb failures --clear   # forget the records → files are retried on next sync
+```
+
+If a file was fixed at the source, no action is needed — a changed checksum is
+retried automatically.
 
 ### How do I find my KB ID?
 

--- a/src/oikb/cli.py
+++ b/src/oikb/cli.py
@@ -1055,6 +1055,53 @@ def history(limit: int, kb_id: str | None, errors: bool, clear: bool, days: int,
             click.echo(click.style(f"  Error: {e['error_message']}", fg="red"))
 
 
+# ── failures ────────────────────────────────────────────────────
+
+@cli.command()
+@click.option("--kb-id", default=None, help="Filter by Knowledge Base ID.")
+@click.option("--clear", is_flag=True, help="Clear failure records (next sync retries the files).")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def failures(kb_id: str | None, clear: bool, as_json: bool):
+    """List files whose upload was permanently rejected by the server (4xx).
+
+    Such files are skipped on subsequent syncs until their content changes.
+    Use --clear to forget the records and retry them on the next sync.
+    """
+    import json as json_mod
+    from oikb.history import SyncHistory
+
+    hist = SyncHistory()
+
+    if clear:
+        count = hist.clear_failures(kb_id=kb_id)
+        hist.close()
+        scope = f" for KB {kb_id}" if kb_id else ""
+        click.echo(f"Cleared {count} failure record(s){scope}. They will be retried on the next sync.")
+        return
+
+    entries = hist.list_failures(kb_id=kb_id)
+    hist.close()
+
+    if as_json:
+        click.echo(json_mod.dumps(entries, indent=2, default=str))
+        return
+
+    if not entries:
+        click.echo("No known failed uploads.")
+        return
+
+    click.echo(f"{'FILE':<60} {'KB-ID':<38} {'FAILED'}")
+    click.echo("-" * 110)
+    for e in entries:
+        path = e.get("path") or ""
+        display = f"{path}/{e['filename']}" if path else e["filename"]
+        kb = (e["kb_id"] or "")[:36]
+        ago = _time_ago(e.get("failed_at", 0))
+        click.echo(f"{display[:58]:<60} {kb:<38} {ago}")
+        if e.get("error"):
+            click.echo(click.style(f"  {e['error'][:100]}", fg="red"))
+
+
 # ── Helpers ─────────────────────────────────────────────────────
 
 def _format_size(size: int) -> str:

--- a/src/oikb/client.py
+++ b/src/oikb/client.py
@@ -90,6 +90,32 @@ class OikbClient:
         resp.raise_for_status()
         return resp.json()
 
+    def get_file_status(self, file_id: str) -> str | None:
+        """GET /files/{id}/process/status.
+
+        Returns 'pending' | 'processing' | 'completed' | 'failed',
+        or None if the file no longer exists server-side (404).
+        """
+        resp = self._http.get(f"/files/{file_id}/process/status")
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json().get("status")
+
+    def add_file_to_kb(
+        self,
+        kb_id: str,
+        file_id: str,
+        directory_id: str | None = None,
+    ) -> dict[str, Any]:
+        """POST /knowledge/{id}/file/add — link an existing file to a KB."""
+        payload: dict[str, Any] = {"file_id": file_id}
+        if directory_id:
+            payload["directory_id"] = directory_id
+        resp = self._http.post(f"/knowledge/{kb_id}/file/add", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
     # ── Directory management ────────────────────────────────────
 
     def create_directory(

--- a/src/oikb/daemon.py
+++ b/src/oikb/daemon.py
@@ -321,6 +321,7 @@ async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
                 "deleted": result.deleted,
                 "unmodified": result.unmodified,
                 "skipped_failed": result.skipped_failed,
+                "skipped_pending": result.skipped_pending,
                 "warnings": result.warnings or [],
                 "errors": result.errors or [],
                 "summary": result.summary(),

--- a/src/oikb/daemon.py
+++ b/src/oikb/daemon.py
@@ -311,6 +311,7 @@ async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
             manifest_filter=mf,
             concurrency=entry.get("concurrency", 1),
             cancel_requested=_shutdown_event.is_set if _shutdown_event else None,
+            history=_history,
         )
 
         if dry_run:
@@ -319,6 +320,7 @@ async def _run_entry_locked(entry: dict, dry_run: bool = False) -> dict | None:
                 "modified": result.modified,
                 "deleted": result.deleted,
                 "unmodified": result.unmodified,
+                "skipped_failed": result.skipped_failed,
                 "warnings": result.warnings or [],
                 "errors": result.errors or [],
                 "summary": result.summary(),

--- a/src/oikb/history.py
+++ b/src/oikb/history.py
@@ -34,6 +34,19 @@ CREATE TABLE IF NOT EXISTS sync_log (
 CREATE INDEX IF NOT EXISTS idx_sync_log_kb_id  ON sync_log(kb_id);
 CREATE INDEX IF NOT EXISTS idx_sync_log_source ON sync_log(source);
 CREATE INDEX IF NOT EXISTS idx_sync_log_status ON sync_log(status);
+
+-- Files whose upload was rejected permanently by the server (4xx). They are
+-- skipped on subsequent syncs until their checksum changes, so a file that
+-- can never be ingested is not re-uploaded on every sync cycle.
+CREATE TABLE IF NOT EXISTS failed_file (
+    kb_id      TEXT NOT NULL,
+    path       TEXT NOT NULL,
+    filename   TEXT NOT NULL,
+    checksum   TEXT NOT NULL,
+    error      TEXT,
+    failed_at  REAL NOT NULL,
+    PRIMARY KEY (kb_id, path, filename)
+);
 """
 
 
@@ -167,12 +180,88 @@ class SyncHistory:
         """Prune entries older than N days. Returns count deleted."""
         if not self._all_conns:
             return 0
-            
+
         cutoff = time.time() - (older_than_days * 86400)
         with self._get_conn() as conn:
             cursor = conn.execute(
                 "DELETE FROM sync_log WHERE created_at < ?", (cutoff,)
             )
+            conn.commit()
+            return cursor.rowcount
+
+    # ── Permanent upload failures ─────────────────────────────
+
+    def record_failure(
+        self,
+        kb_id: str,
+        path: str,
+        filename: str,
+        checksum: str,
+        error: str | None = None,
+    ) -> None:
+        """Record a permanently rejected upload (server 4xx)."""
+        if not self._all_conns:
+            return
+
+        with self._get_conn() as conn:
+            conn.execute(
+                """INSERT OR REPLACE INTO failed_file
+                   (kb_id, path, filename, checksum, error, failed_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (kb_id, path, filename, checksum, error, time.time()),
+            )
+            conn.commit()
+
+    def clear_failure(self, kb_id: str, path: str, filename: str) -> None:
+        """Drop a failure record (e.g. after a successful upload)."""
+        if not self._all_conns:
+            return
+
+        with self._get_conn() as conn:
+            conn.execute(
+                "DELETE FROM failed_file WHERE kb_id = ? AND path = ? AND filename = ?",
+                (kb_id, path, filename),
+            )
+            conn.commit()
+
+    def failed_checksums(self, kb_id: str) -> dict[tuple[str, str], str]:
+        """Map of (path, filename) -> checksum for known failed uploads."""
+        if not self._all_conns:
+            return {}
+
+        with self._get_conn() as conn:
+            rows = conn.execute(
+                "SELECT path, filename, checksum FROM failed_file WHERE kb_id = ?",
+                (kb_id,),
+            ).fetchall()
+            return {(row["path"], row["filename"]): row["checksum"] for row in rows}
+
+    def list_failures(self, kb_id: str | None = None) -> list[dict[str, Any]]:
+        """List known failed uploads, newest first."""
+        if not self._all_conns:
+            return []
+
+        sql = "SELECT * FROM failed_file"
+        params: list[Any] = []
+        if kb_id:
+            sql += " WHERE kb_id = ?"
+            params.append(kb_id)
+        sql += " ORDER BY failed_at DESC"
+
+        with self._get_conn() as conn:
+            rows = conn.execute(sql, params).fetchall()
+            return [dict(row) for row in rows]
+
+    def clear_failures(self, kb_id: str | None = None) -> int:
+        """Clear failure records (optionally per KB). Returns count deleted."""
+        if not self._all_conns:
+            return 0
+
+        with self._get_conn() as conn:
+            if kb_id:
+                cursor = conn.execute("DELETE FROM failed_file WHERE kb_id = ?", (kb_id,))
+            else:
+                cursor = conn.execute("DELETE FROM failed_file")
             conn.commit()
             return cursor.rowcount
 

--- a/src/oikb/history.py
+++ b/src/oikb/history.py
@@ -47,6 +47,21 @@ CREATE TABLE IF NOT EXISTS failed_file (
     failed_at  REAL NOT NULL,
     PRIMARY KEY (kb_id, path, filename)
 );
+
+-- Files successfully handed to the server (upload HTTP 200) whose ingestion
+-- runs asynchronously. Tracked so the next sync can check their server-side
+-- status instead of blindly re-uploading them when the diff reports them as
+-- "added" again (which happens for every file that never gets linked to the
+-- KB — e.g. rejected during async processing).
+CREATE TABLE IF NOT EXISTS uploaded_file (
+    kb_id       TEXT NOT NULL,
+    path        TEXT NOT NULL,
+    filename    TEXT NOT NULL,
+    checksum    TEXT NOT NULL,
+    file_id     TEXT NOT NULL,
+    uploaded_at REAL NOT NULL,
+    PRIMARY KEY (kb_id, path, filename)
+);
 """
 
 
@@ -264,6 +279,59 @@ class SyncHistory:
                 cursor = conn.execute("DELETE FROM failed_file")
             conn.commit()
             return cursor.rowcount
+
+    # ── Async upload tracking ─────────────────────────────────
+
+    def record_upload(
+        self,
+        kb_id: str,
+        path: str,
+        filename: str,
+        checksum: str,
+        file_id: str,
+    ) -> None:
+        """Track a file that was accepted by the server (upload HTTP 200)."""
+        if not self._all_conns:
+            return
+
+        with self._get_conn() as conn:
+            conn.execute(
+                """INSERT OR REPLACE INTO uploaded_file
+                   (kb_id, path, filename, checksum, file_id, uploaded_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (kb_id, path, filename, checksum, file_id, time.time()),
+            )
+            conn.commit()
+
+    def untrack_upload(self, kb_id: str, path: str, filename: str) -> None:
+        """Stop tracking an upload (linked, failed, or gone server-side)."""
+        if not self._all_conns:
+            return
+
+        with self._get_conn() as conn:
+            conn.execute(
+                "DELETE FROM uploaded_file WHERE kb_id = ? AND path = ? AND filename = ?",
+                (kb_id, path, filename),
+            )
+            conn.commit()
+
+    def tracked_uploads(self, kb_id: str) -> dict[tuple[str, str], dict[str, str]]:
+        """Map of (path, filename) -> {checksum, file_id} for tracked uploads."""
+        if not self._all_conns:
+            return {}
+
+        with self._get_conn() as conn:
+            rows = conn.execute(
+                "SELECT path, filename, checksum, file_id FROM uploaded_file WHERE kb_id = ?",
+                (kb_id,),
+            ).fetchall()
+            return {
+                (row["path"], row["filename"]): {
+                    "checksum": row["checksum"],
+                    "file_id": row["file_id"],
+                }
+                for row in rows
+            }
 
     def close(self) -> None:
         """Close all connections in the pool."""

--- a/src/oikb/sync.py
+++ b/src/oikb/sync.py
@@ -22,9 +22,16 @@ from rich.progress import (
 
 from oikb.client import OikbClient
 from oikb.connectors import BaseConnector, ManifestEntry, SourceFileUnavailable
+from oikb.history import SyncHistory
 
 # Stderr console for progress output (keeps stdout clean for piping).
 _console = Console(stderr=True)
+
+# HTTP statuses that mean "this file will never be accepted as-is"
+# (rejected content, conflicts, too large, unsupported type). Auth failures
+# (401/403) are deliberately excluded — they are config problems that must
+# keep surfacing as errors on every run, not get silently skipped.
+_PERMANENT_UPLOAD_STATUSES = frozenset({400, 409, 413, 415, 422})
 
 
 @dataclass
@@ -37,6 +44,7 @@ class SyncResult:
     unmodified: int = 0
     dirs_created: int = 0
     dirs_removed: int = 0
+    skipped_failed: int = 0
     errors: list[str] | None = None
     warnings: list[str] | None = None
 
@@ -58,6 +66,8 @@ class SyncResult:
             parts.append(f"{self.dirs_created} dirs created")
         if self.dirs_removed:
             parts.append(f"{self.dirs_removed} dirs removed")
+        if self.skipped_failed:
+            parts.append(f"{self.skipped_failed} skipped (known failures)")
         return ", ".join(parts) if parts else "nothing to do"
 
 
@@ -141,6 +151,7 @@ def run_sync(
     manifest_filter: Callable[[list[ManifestEntry]], list[ManifestEntry]] | None = None,
     concurrency: int = 1,
     cancel_requested: Callable[[], bool] | None = None,
+    history: SyncHistory | None = None,
 ) -> SyncResult:
     """Execute a full incremental sync.
 
@@ -151,18 +162,27 @@ def run_sync(
       4. Cleanup stale files (delete before upload)
       5. Create missing directories
       6. Upload added + modified files
+
+    Files whose upload was previously rejected with a permanent (4xx) status
+    are skipped until their checksum changes (see SyncHistory.failed_file).
     """
     result = SyncResult()
     result.errors = []
     result.warnings = []
 
+    owns_history = history is None
+    if history is None:
+        history = SyncHistory()
+
     try:
         return _run_sync_inner(
             client, connector, kb_id, dry_run, verbose, quiet,
-            manifest_filter, concurrency, result, cancel_requested,
+            manifest_filter, concurrency, result, cancel_requested, history,
         )
     finally:
         connector.close()
+        if owns_history and history is not None:
+            history.close()
 
 
 def _run_sync_inner(
@@ -176,6 +196,7 @@ def _run_sync_inner(
     concurrency: int,
     result: SyncResult,
     cancel_requested: Callable[[], bool] | None,
+    history: SyncHistory | None,
 ) -> SyncResult:
     """Inner sync logic, separated for clean connector cleanup."""
     show_progress = not quiet and not dry_run
@@ -230,6 +251,33 @@ def _run_sync_inner(
     directory_map: dict[str, str] = diff.get("directory_map", {})
 
     result.unmodified = unmodified_count
+
+    # ── 3b. Skip files with known permanent failures ──────────
+    manifest_by_key = {(e.path, e.filename): e for e in manifest}
+
+    known_failures = history.failed_checksums(kb_id) if history else {}
+    if known_failures:
+        def _is_known_failure(entry: dict[str, Any]) -> bool:
+            key = (entry.get("path", ""), entry["filename"])
+            manifest_entry = manifest_by_key.get(key)
+            return (
+                manifest_entry is not None
+                and known_failures.get(key) == manifest_entry.checksum
+            )
+
+        before = len(added) + len(modified)
+        added = [e for e in added if not _is_known_failure(e)]
+        modified = [e for e in modified if not _is_known_failure(e)]
+        result.skipped_failed = before - len(added) - len(modified)
+        if result.skipped_failed and not quiet:
+            click.echo(
+                click.style(
+                    f"  Skipping {result.skipped_failed} file(s) previously rejected "
+                    f"by the server (manage via 'oikb failures')",
+                    fg="yellow",
+                ),
+                err=True,
+            )
 
     if show_progress:
         parts = []
@@ -319,7 +367,6 @@ def _run_sync_inner(
         result.dirs_created += 1
 
     # ── 6. Upload files ────────────────────────────────────────
-    manifest_by_key = {(e.path, e.filename): e for e in manifest}
 
     files_to_upload = [
         *[(a, "added") for a in added],
@@ -361,6 +408,8 @@ def _run_sync_inner(
                 )
                 if progress is not None:
                     progress.update(task_id, advance=1, description=f"[cyan]{display}[/cyan]")
+                if history is not None:
+                    history.clear_failure(kb_id, path, filename)
                 return (change_type, None)
             except SourceFileUnavailable as e:
                 message = f"{display}: {e}"
@@ -387,6 +436,14 @@ def _run_sync_inner(
             progress.update(task_id, advance=1, description=f"[red]✗ {display}[/red]")
         else:
             click.echo(click.style(f"  ✗ {display}: {last_err}", fg="red"), err=True)
+        if (
+            history is not None
+            and isinstance(last_err, httpx.HTTPStatusError)
+            and last_err.response.status_code in _PERMANENT_UPLOAD_STATUSES
+        ):
+            history.record_failure(
+                kb_id, path, filename, manifest_entry.checksum, str(last_err)
+            )
         return ("error", f"{display}: {last_err}")
 
     def _tally(outcome: tuple[str, str | None]) -> None:

--- a/src/oikb/sync.py
+++ b/src/oikb/sync.py
@@ -45,6 +45,7 @@ class SyncResult:
     dirs_created: int = 0
     dirs_removed: int = 0
     skipped_failed: int = 0
+    skipped_pending: int = 0
     errors: list[str] | None = None
     warnings: list[str] | None = None
 
@@ -68,6 +69,8 @@ class SyncResult:
             parts.append(f"{self.dirs_removed} dirs removed")
         if self.skipped_failed:
             parts.append(f"{self.skipped_failed} skipped (known failures)")
+        if self.skipped_pending:
+            parts.append(f"{self.skipped_pending} skipped (still processing)")
         return ", ".join(parts) if parts else "nothing to do"
 
 
@@ -279,6 +282,77 @@ def _run_sync_inner(
                 err=True,
             )
 
+    # ── 3c. Reconcile tracked uploads instead of re-uploading ──
+    # The server ingests uploads asynchronously and never reports ingestion
+    # failures to the upload call (HTTP 200, then the file silently lands in
+    # status 'failed' or is never linked to the KB). Such files reappear as
+    # "added" in every diff. Instead of re-uploading them (which would create
+    # yet another server-side copy each cycle), check their stored status.
+    if history and not dry_run:
+        tracked = history.tracked_uploads(kb_id)
+        if tracked:
+            reported = {(e.get("path", ""), e["filename"]) for e in (*added, *modified)}
+
+            def _drop(key: tuple[str, str]) -> None:
+                nonlocal added, modified
+                added = [e for e in added if (e.get("path", ""), e["filename"]) != key]
+                modified = [e for e in modified if (e.get("path", ""), e["filename"]) != key]
+
+            for key, rec in tracked.items():
+                if key not in reported:
+                    # No longer reported as changed → linked fine (or removed
+                    # from the source and handled by cleanup). Stop tracking.
+                    history.untrack_upload(kb_id, *key)
+                    continue
+
+                manifest_entry = manifest_by_key.get(key)
+                if manifest_entry is None or manifest_entry.checksum != rec["checksum"]:
+                    continue  # source changed → fall through to normal re-upload
+
+                try:
+                    status = client.get_file_status(rec["file_id"])
+                except Exception:
+                    status = "unknown"
+
+                if status in ("pending", "processing", "unknown"):
+                    # Still ingesting (or status unreadable) → skip this run,
+                    # check again on the next one. No re-upload.
+                    _drop(key)
+                    result.skipped_pending += 1
+                elif status == "failed":
+                    history.record_failure(
+                        kb_id, key[0], key[1], rec["checksum"],
+                        "server-side ingestion failed",
+                    )
+                    history.untrack_upload(kb_id, *key)
+                    _drop(key)
+                    result.skipped_failed += 1
+                elif status == "completed":
+                    # Processed fine but never linked (e.g. duplicate content
+                    # rejection, or manual removal from the KB). Try re-linking
+                    # the existing file instead of uploading another copy.
+                    try:
+                        client.add_file_to_kb(
+                            kb_id, rec["file_id"],
+                            directory_id=directory_map.get(key[0]) or None,
+                        )
+                        history.untrack_upload(kb_id, *key)
+                        _drop(key)
+                    except httpx.HTTPStatusError as e:
+                        if e.response.status_code in _PERMANENT_UPLOAD_STATUSES:
+                            history.record_failure(
+                                kb_id, key[0], key[1], rec["checksum"], str(e)
+                            )
+                            history.untrack_upload(kb_id, *key)
+                            _drop(key)
+                            result.skipped_failed += 1
+                        else:
+                            raise
+                else:
+                    # File is gone server-side (None) → stop tracking and let
+                    # the normal upload path below re-upload it.
+                    history.untrack_upload(kb_id, *key)
+
     if show_progress:
         parts = []
         if added:
@@ -399,7 +473,7 @@ def _run_sync_inner(
                 content = connector.read_file(path, filename)
                 check_stop()
                 directory_id = directory_map.get(path) if path else None
-                client.upload_file(
+                resp = client.upload_file(
                     file_content=content,
                     filename=filename,
                     kb_id=kb_id,
@@ -410,6 +484,11 @@ def _run_sync_inner(
                     progress.update(task_id, advance=1, description=f"[cyan]{display}[/cyan]")
                 if history is not None:
                     history.clear_failure(kb_id, path, filename)
+                    file_id = resp.get("id") if isinstance(resp, dict) else None
+                    if file_id:
+                        history.record_upload(
+                            kb_id, path, filename, manifest_entry.checksum, file_id
+                        )
                 return (change_type, None)
             except SourceFileUnavailable as e:
                 message = f"{display}: {e}"


### PR DESCRIPTION
Fixes #106.

When Open WebUI rejects a file during ingestion, it is never linked to the KB, so `/sync/diff` reports it as "added" on every subsequent sync and oikb re-uploads it on every cycle. Every upload creates a new file record and physical copy server-side, which accumulates unboundedly (orphaned records, disk growth).

There are two rejection channels, both handled:

- **Synchronous:** the upload POST itself returns 4xx → recorded immediately in the state DB.
- **Asynchronous (dominant):** uploads return HTTP 200 while ingestion runs in the background; processing errors are swallowed server-side (file status `failed`, or processed but never linked). Accepted uploads are now tracked (checksum + file id). When the diff reports a tracked file again, oikb checks `GET /files/{id}/process/status` instead of re-uploading:
  - `failed` → recorded as permanent failure, skipped
  - `completed` but unlinked → the existing file is re-linked in place (no second copy)
  - `pending`/`processing` → skipped for that run, checked again next run
  - gone (404) → untracked and re-uploaded normally

Notes:

- Auth failures (401/403) are deliberately **never** recorded, so config problems keep surfacing as errors on every run instead of being silently skipped.
- A changed source checksum is always retried (records are keyed with the checksum).
- Successful uploads clear any previous failure record.
- Tracked uploads that the diff no longer reports are untracked again, so the table stays small.
- New `oikb failures` command (`--kb-id`, `--clear`, `--json`) to inspect/reset recorded rejections.
- Sync results gained `skipped_failed` / `skipped_pending` counters (CLI summary + daemon dry-run response).

#### Test plan

- [x] Unit-level: stubbed connector + client covering both channels (sync 4xx, async `failed`, pending→linked, completed-unlinked→re-link, re-link rejected→permanent)
- [x] Verified against a live Open WebUI instance with a real file that always fails ingestion (empty-content rejection): one final upload, status-detected on the next sync, skipped from then on — no further file records created server-side